### PR TITLE
combine color and shape info in single struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ This package provides fast drawing methods for the following simple shapes:
 ### Line
 
 ```julia
-mutable struct Line{I <: Integer} <: AbstractShape
+mutable struct Line{I <: Integer, C} <: AbstractDrawable
     i1::I
     j1::I
     i2::I
     j2::I
+    color::C
 end
 ```
 
@@ -24,10 +25,11 @@ end
 ### Circle
 
 ```julia
-mutable struct Circle{I <: Integer} <: AbstractShape
+mutable struct Circle{I <: Integer, C} <: AbstractDrawable
     i_center::I
     j_center::I
     radius::I
+    color::C
 end
 ```
 
@@ -36,10 +38,11 @@ end
 ### FilledCircle
 
 ```julia
-mutable struct FilledCircle{I <: Integer} <: AbstractShape
+mutable struct FilledCircle{I <: Integer, C} <: AbstractDrawable
     i_center::I
     j_center::I
     radius::I
+    color::C
 end
 ```
 
@@ -48,11 +51,12 @@ end
 ### Rectangle
 
 ```julia
-mutable struct Rectangle{I <: Integer} <: AbstractShape
+mutable struct Rectangle{I <: Integer, C} <: AbstractDrawable
     i_top_left::I
     j_top_left::I
     height::I
     width::I
+    color::C
 end
 ```
 
@@ -61,11 +65,12 @@ end
 ### FilledRectangle
 
 ```julia
-mutable struct FilledRectangle{I <: Integer} <: AbstractShape
+mutable struct FilledRectangle{I <: Integer, C} <: AbstractDrawable
     i_top_left::I
     j_top_left::I
     height::I
     width::I
+    color::C
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ mutable struct Line{I <: Integer, C} <: AbstractDrawable
 end
 ```
 
-<img src="https://user-images.githubusercontent.com/32610387/123078332-7d471680-d438-11eb-9216-0f0b41efdbd6.png">
+<img src="https://user-images.githubusercontent.com/32610387/132089909-fd6313af-b9be-4f61-8e53-387c699a83e4.png">
 
 ### Circle
 
@@ -33,7 +33,7 @@ mutable struct Circle{I <: Integer, C} <: AbstractDrawable
 end
 ```
 
-<img src="https://user-images.githubusercontent.com/32610387/123078423-95b73100-d438-11eb-8329-546982bbb00c.png">
+<img src="https://user-images.githubusercontent.com/32610387/132089918-7b5e28b6-b934-40bf-80c1-95e5d531ba54.png">
 
 ### FilledCircle
 
@@ -46,7 +46,7 @@ mutable struct FilledCircle{I <: Integer, C} <: AbstractDrawable
 end
 ```
 
-<img src="https://user-images.githubusercontent.com/32610387/123078474-a2d42000-d438-11eb-88cf-d0635380a21f.png">
+<img src="https://user-images.githubusercontent.com/32610387/132089928-52124907-8fc6-42a2-84d4-530b2de66399.png">
 
 ### Rectangle
 
@@ -60,7 +60,7 @@ mutable struct Rectangle{I <: Integer, C} <: AbstractDrawable
 end
 ```
 
-<img src="https://user-images.githubusercontent.com/32610387/123078509-ac5d8800-d438-11eb-814f-b7fa32857878.png">
+<img src="https://user-images.githubusercontent.com/32610387/132089933-cc390f7c-9adc-4c82-b62f-4487f9c1ebef.png">
 
 ### FilledRectangle
 
@@ -74,4 +74,4 @@ mutable struct FilledRectangle{I <: Integer, C} <: AbstractDrawable
 end
 ```
 
-<img src="https://user-images.githubusercontent.com/32610387/123078547-b67f8680-d438-11eb-94be-af77c473d0e9.png">
+<img src="https://user-images.githubusercontent.com/32610387/132089939-4871bd2e-eb4f-41ea-8550-98a97b14a3aa.png">

--- a/src/SimpleDraw.jl
+++ b/src/SimpleDraw.jl
@@ -1,6 +1,6 @@
 module SimpleDraw
 
-abstract type AbstractShape end
+abstract type AbstractDrawable end
 
 include("line.jl")
 include("circle.jl")

--- a/src/circle.jl
+++ b/src/circle.jl
@@ -1,13 +1,15 @@
-mutable struct Circle{I <: Integer} <: AbstractShape
+mutable struct Circle{I <: Integer, C} <: AbstractDrawable
     i_center::I
     j_center::I
     radius::I
+    color::C
 end
 
-mutable struct FilledCircle{I <: Integer} <: AbstractShape
+mutable struct FilledCircle{I <: Integer, C} <: AbstractDrawable
     i_center::I
     j_center::I
     radius::I
+    color::C
 end
 
 @inline function draw_vertical_strip_reflections!(image::AbstractMatrix, i_center::Integer, j_center::Integer, i::Integer, j::Integer, color)
@@ -35,10 +37,11 @@ end
 """
 Draw a circle. Ref: https://en.wikipedia.org/wiki/Midpoint_circle_algorithm variant with integer-based arithmetic
 """
-function draw!(image::AbstractMatrix, shape::Circle{I}, color) where {I}
-    i_center = shape.i_center
-    j_center = shape.j_center
-    radius = shape.radius
+function draw!(image::AbstractMatrix, drawable::Circle{I}) where {I}
+    i_center = drawable.i_center
+    j_center = drawable.j_center
+    radius = drawable.radius
+    color = drawable.color
 
     zero_value = zero(I)
 
@@ -64,10 +67,11 @@ function draw!(image::AbstractMatrix, shape::Circle{I}, color) where {I}
     return nothing
 end
 
-function draw!(image::AbstractMatrix, shape::FilledCircle{I}, color) where {I}
-    i_center = shape.i_center
-    j_center = shape.j_center
-    radius = shape.radius
+function draw!(image::AbstractMatrix, drawable::FilledCircle{I}) where {I}
+    i_center = drawable.i_center
+    j_center = drawable.j_center
+    radius = drawable.radius
+    color = drawable.color
 
     zero_value = zero(I)
 

--- a/src/line.jl
+++ b/src/line.jl
@@ -1,18 +1,20 @@
-mutable struct Line{I <: Integer} <: AbstractShape
+mutable struct Line{I <: Integer, C} <: AbstractDrawable
     i1::I
     j1::I
     i2::I
     j2::I
+    color::C
 end
 
 """
 Draw a line. Ref: https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm
 """
-function draw!(image::AbstractMatrix, shape::Line, color)
-    i1 = shape.i1
-    j1 = shape.j1
-    i2 = shape.i2
-    j2 = shape.j2
+function draw!(image::AbstractMatrix, drawable::Line)
+    i1 = drawable.i1
+    j1 = drawable.j1
+    i2 = drawable.i2
+    j2 = drawable.j2
+    color = drawable.color
 
     di = abs(i2 - i1)
     dj = -abs(j2 - j1)

--- a/src/rectangle.jl
+++ b/src/rectangle.jl
@@ -1,22 +1,25 @@
-mutable struct Rectangle{I <: Integer} <: AbstractShape
+mutable struct Rectangle{I <: Integer, C} <: AbstractDrawable
     i_top_left::I
     j_top_left::I
     height::I
     width::I
+    color::C
 end
 
-mutable struct FilledRectangle{I <: Integer} <: AbstractShape
+mutable struct FilledRectangle{I <: Integer, C} <: AbstractDrawable
     i_top_left::I
     j_top_left::I
     height::I
     width::I
+    color::C
 end
 
-function draw!(image::AbstractMatrix, shape::Rectangle, color)
-    i_top_left = shape.i_top_left
-    j_top_left = shape.j_top_left
-    i_bottom_right = i_top_left + shape.height - 1
-    j_bottom_right = j_top_left + shape.width - 1
+function draw!(image::AbstractMatrix, drawable::Rectangle)
+    i_top_left = drawable.i_top_left
+    j_top_left = drawable.j_top_left
+    i_bottom_right = i_top_left + drawable.height - 1
+    j_bottom_right = j_top_left + drawable.width - 1
+    color = drawable.color
 
     image[i_top_left:i_bottom_right, j_top_left] .= color
     image[i_top_left:i_bottom_right, j_bottom_right] .= color
@@ -26,11 +29,12 @@ function draw!(image::AbstractMatrix, shape::Rectangle, color)
     return nothing
 end
 
-function draw!(image::AbstractMatrix, shape::FilledRectangle, color)
-    i_top_left = shape.i_top_left
-    j_top_left = shape.j_top_left
-    i_bottom_right = i_top_left + shape.height - 1
-    j_bottom_right = j_top_left + shape.width - 1
+function draw!(image::AbstractMatrix, drawable::FilledRectangle)
+    i_top_left = drawable.i_top_left
+    j_top_left = drawable.j_top_left
+    i_bottom_right = i_top_left + drawable.height - 1
+    j_bottom_right = j_top_left + drawable.width - 1
+    color = drawable.color
 
     image[i_top_left:i_bottom_right, j_top_left:j_bottom_right] .= color
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,8 +7,8 @@ Test.@testset "SimpleDraw.jl" begin
         height = 16
         width = 16
         image = falses(height, width)
-        shape = SD.Line(2, 2, height - 1, width - 1)
-        SD.draw!(image, shape, true)
+        drawable = SD.Line(2, 2, height - 1, width - 1, true)
+        SD.draw!(image, drawable)
         Test.@test image == BitArray([
                                       0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
                                       0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0
@@ -33,8 +33,8 @@ Test.@testset "SimpleDraw.jl" begin
         height = 16
         width = 16
         image = falses(height, width)
-        shape = SD.Circle(8, 8, 6)
-        SD.draw!(image, shape, true)
+        drawable = SD.Circle(8, 8, 6, true)
+        SD.draw!(image, drawable)
         Test.@test image == BitArray([
                                       0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
                                       0 0 0 0 0 1 1 1 1 1 0 0 0 0 0 0
@@ -59,8 +59,8 @@ Test.@testset "SimpleDraw.jl" begin
         height = 16
         width = 16
         image = falses(height, width)
-        shape = SD.FilledCircle(8, 8, 6)
-        SD.draw!(image, shape, true)
+        drawable = SD.FilledCircle(8, 8, 6, true)
+        SD.draw!(image, drawable)
         Test.@test image == BitArray([
                                       0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
                                       0 0 0 0 0 1 1 1 1 1 0 0 0 0 0 0
@@ -85,8 +85,8 @@ Test.@testset "SimpleDraw.jl" begin
         height = 16
         width = 16
         image = falses(height, width)
-        shape = SD.Rectangle(2, 2, height - 2, width - 2)
-        SD.draw!(image, shape, true)
+        drawable = SD.Rectangle(2, 2, height - 2, width - 2, true)
+        SD.draw!(image, drawable)
         Test.@test image == BitArray([
                                       0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
                                       0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0
@@ -111,8 +111,8 @@ Test.@testset "SimpleDraw.jl" begin
         height = 16
         width = 16
         image = falses(height, width)
-        shape = SD.FilledRectangle(2, 2, height - 2, width - 2)
-        SD.draw!(image, shape, true)
+        drawable = SD.FilledRectangle(2, 2, height - 2, width - 2, true)
+        SD.draw!(image, drawable)
         Test.@test image == BitArray([
                                       0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
                                       0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0


### PR DESCRIPTION
1. Combine color and shape info in single struct for all shapes. Remove `AbstractShape` and add `AbstractDrawable`.
2. Update tests.
3. Update README.

`Line`:
![line](https://user-images.githubusercontent.com/32610387/132089909-fd6313af-b9be-4f61-8e53-387c699a83e4.png)

`Circle`:
![circle](https://user-images.githubusercontent.com/32610387/132089918-7b5e28b6-b934-40bf-80c1-95e5d531ba54.png)

`FilledCircle`:
![filled_circle](https://user-images.githubusercontent.com/32610387/132089928-52124907-8fc6-42a2-84d4-530b2de66399.png)

`Rectangle`:
![rectangle](https://user-images.githubusercontent.com/32610387/132089933-cc390f7c-9adc-4c82-b62f-4487f9c1ebef.png)

`FilledRectangle`:
![filled_rectangle](https://user-images.githubusercontent.com/32610387/132089939-4871bd2e-eb4f-41ea-8550-98a97b14a3aa.png)