### PR TITLE
add put_pixel! method for clipped drawing

### DIFF
--- a/src/SimpleDraw.jl
+++ b/src/SimpleDraw.jl
@@ -2,6 +2,14 @@ module SimpleDraw
 
 abstract type AbstractDrawable end
 
+@inline function put_pixel!(image, i, j, color)
+    if checkbounds(Bool, image, i, j)
+        @inbounds image[i, j] = color
+    end
+
+    return nothing
+end
+
 include("background.jl")
 include("line.jl")
 include("circle.jl")

--- a/src/circle.jl
+++ b/src/circle.jl
@@ -13,23 +13,34 @@ mutable struct FilledCircle{I <: Integer, C} <: AbstractDrawable
 end
 
 @inline function draw_vertical_strip_reflections!(image::AbstractMatrix, i_center::Integer, j_center::Integer, i::Integer, j::Integer, color)
-    image[i_center - i : i_center + i, j_center - j] .= color
-    image[i_center - j : i_center + j, j_center - i] .= color
-    image[i_center - j : i_center + j, j_center + i] .= color
-    image[i_center - i : i_center + i, j_center + j] .= color
+    for ii in i_center - i : i_center + i
+        put_pixel!(image, ii, j_center - j, color)
+    end
+
+    for ii in i_center - j : i_center + j
+        put_pixel!(image, ii, j_center - i, color)
+    end
+
+    for ii in i_center - j : i_center + j
+        put_pixel!(image, ii, j_center + i, color)
+    end
+
+    for ii in i_center - i : i_center + i
+        put_pixel!(image, ii, j_center + j, color)
+    end
 
     return nothing
 end
 
 @inline function draw_octant_reflections!(image::AbstractMatrix, i_center::Integer, j_center::Integer, i::Integer, j::Integer, color)
-    image[i_center - i, j_center - j] = color
-    image[i_center + i, j_center - j] = color
-    image[i_center - j, j_center - i] = color
-    image[i_center + j, j_center - i] = color
-    image[i_center - j, j_center + i] = color
-    image[i_center + j, j_center + i] = color
-    image[i_center - i, j_center + j] = color
-    image[i_center + i, j_center + j] = color
+    put_pixel!(image, i_center - i, j_center - j, color)
+    put_pixel!(image, i_center + i, j_center - j, color)
+    put_pixel!(image, i_center - j, j_center - i, color)
+    put_pixel!(image, i_center + j, j_center - i, color)
+    put_pixel!(image, i_center - j, j_center + i, color)
+    put_pixel!(image, i_center + j, j_center + i, color)
+    put_pixel!(image, i_center - i, j_center + j, color)
+    put_pixel!(image, i_center + i, j_center + j, color)
 
     return nothing
 end

--- a/src/line.jl
+++ b/src/line.jl
@@ -23,7 +23,7 @@ function draw!(image::AbstractMatrix, drawable::Line)
     err = di + dj
 
     while true
-        image[i1, j1] = color
+        put_pixel!(image, i1, j1, color)
 
         if (i1 == i2 && j1 == j2)
             break

--- a/src/rectangle.jl
+++ b/src/rectangle.jl
@@ -21,10 +21,21 @@ function draw!(image::AbstractMatrix, drawable::Rectangle)
     j_bottom_right = j_top_left + drawable.width - 1
     color = drawable.color
 
-    image[i_top_left:i_bottom_right, j_top_left] .= color
-    image[i_top_left:i_bottom_right, j_bottom_right] .= color
-    image[i_top_left, j_top_left:j_bottom_right] .= color
-    image[i_bottom_right, j_top_left:j_bottom_right] .= color
+    for i in i_top_left:i_bottom_right
+        put_pixel!(image, i, j_top_left, color)
+    end
+
+    for i in i_top_left:i_bottom_right
+        put_pixel!(image, i, j_bottom_right, color)
+    end
+
+    for j in j_top_left:j_bottom_right
+        put_pixel!(image, i_top_left, j, color)
+    end
+
+    for j in j_top_left:j_bottom_right
+        put_pixel!(image, i_bottom_right, j, color)
+    end
 
     return nothing
 end
@@ -36,7 +47,11 @@ function draw!(image::AbstractMatrix, drawable::FilledRectangle)
     j_bottom_right = j_top_left + drawable.width - 1
     color = drawable.color
 
-    image[i_top_left:i_bottom_right, j_top_left:j_bottom_right] .= color
+    for j in j_top_left:j_bottom_right
+        for i in i_top_left:i_bottom_right
+            put_pixel!(image, i, j, color)
+        end
+    end
 
     return nothing
 end


### PR DESCRIPTION
1. Add `put_pixel!` method. It puts a pixel if the indices lies inside the image. This allows one to safely draw without worrying about out of bounds errors.
2. Use `put_pixel!` inside the `draw!` methods for existing drawables.