### PR TITLE
add get_bounding_box methods for all shapes

### DIFF
--- a/src/character.jl
+++ b/src/character.jl
@@ -77,3 +77,13 @@ function draw_inbounds!(image::AbstractMatrix, shape::Character, color)
 
     return nothing
 end
+
+function get_bounding_box(shape::Character)
+    position = shape.position
+    bitmap = shape.font.bitmap
+
+    height = size(bitmap, 1)
+    width = size(bitmap, 2)
+
+    return Rectangle(position, height, width)
+end

--- a/src/circle.jl
+++ b/src/circle.jl
@@ -329,3 +329,13 @@ function draw_inbounds!(image::AbstractMatrix, shape::ThickCircle{I}, color) whe
 
     return nothing
 end
+
+function get_bounding_box(shape::Circle)
+    center = shape.center
+    radius = shape.radius
+    i = center.i
+    j = center.j
+    side = 2 * radius + 1
+
+    return Rectangle(Point(i - radius, j - radius), side, side)
+end

--- a/src/circle.jl
+++ b/src/circle.jl
@@ -341,3 +341,5 @@ function get_bounding_box(shape::Circle)
 end
 
 get_bounding_box(shape::ThickCircle) = get_bounding_box(Circle(shape.center, shape.radius))
+
+get_bounding_box(shape::FilledCircle) = get_bounding_box(Circle(shape.center, shape.radius))

--- a/src/circle.jl
+++ b/src/circle.jl
@@ -339,3 +339,5 @@ function get_bounding_box(shape::Circle)
 
     return Rectangle(Point(i - radius, j - radius), side, side)
 end
+
+get_bounding_box(shape::ThickCircle) = get_bounding_box(Circle(shape.center, shape.radius))

--- a/src/cross.jl
+++ b/src/cross.jl
@@ -87,3 +87,6 @@ function draw_inbounds!(image::AbstractMatrix, shape::HollowCross, color)
 
     return nothing
 end
+
+get_bounding_box(shape::Cross) = get_bounding_box(Circle(shape.center, shape.radius))
+get_bounding_box(shape::HollowCross) = get_bounding_box(Circle(shape.center, shape.radius))

--- a/src/line.jl
+++ b/src/line.jl
@@ -253,3 +253,5 @@ function draw_inbounds!(image::AbstractMatrix, shape::ThickLine, color)
 end
 
 get_bounding_box(shape::VerticalLine{I}) where {I} = Rectangle(Point(shape.i_start, shape.j), shape.i_end - shape.i_start + one(I), one(I))
+
+get_bounding_box(shape::HorizontalLine{I}) where {I} = Rectangle(Point(shape.i, shape.j_start), one(I), shape.j_end - shape.j_start + one(I))

--- a/src/line.jl
+++ b/src/line.jl
@@ -255,3 +255,30 @@ end
 get_bounding_box(shape::VerticalLine{I}) where {I} = Rectangle(Point(shape.i_start, shape.j), shape.i_end - shape.i_start + one(I), one(I))
 
 get_bounding_box(shape::HorizontalLine{I}) where {I} = Rectangle(Point(shape.i, shape.j_start), one(I), shape.j_end - shape.j_start + one(I))
+
+function get_bounding_box(shape::Line{I}) where {I}
+    point1 = shape.point1
+    point2 = shape.point2
+    i1 = point1.i
+    j1 = point1.j
+    i2 = point2.i
+    j2 = point2.j
+
+    if i1 < i2
+        i_min = i1
+        height = i2 - i1 + one(I)
+    else
+        i_min = i2
+        height = i1 - i2 + one(I)
+    end
+
+    if j1 < j2
+        j_min = j1
+        width = j2 - j1 + one(I)
+    else
+        j_min = j2
+        width = j1 - j2 + one(I)
+    end
+
+    return Rectangle(Point(i_min, j_min), height, width)
+end

--- a/src/line.jl
+++ b/src/line.jl
@@ -251,3 +251,5 @@ function draw_inbounds!(image::AbstractMatrix, shape::ThickLine, color)
 
     return nothing
 end
+
+get_bounding_box(shape::VerticalLine{I}) where {I} = Rectangle(Point(shape.i_start, shape.j), shape.i_end - shape.i_start + one(I), one(I))

--- a/src/line.jl
+++ b/src/line.jl
@@ -282,3 +282,32 @@ function get_bounding_box(shape::Line{I}) where {I}
 
     return Rectangle(Point(i_min, j_min), height, width)
 end
+
+function get_bounding_box(shape::ThickLine{I}) where {I}
+    point1 = shape.point1
+    point2 = shape.point2
+    radius = shape.radius
+    radius2 = 2 * radius
+    i1 = point1.i
+    j1 = point1.j
+    i2 = point2.i
+    j2 = point2.j
+
+    if i1 < i2
+        i_min = i1 - radius
+        height = i2 - i1 + one(I)
+    else
+        i_min = i2 - radius
+        height = i1 - i2 + one(I)
+    end
+
+    if j1 < j2
+        j_min = j1 - radius
+        width = j2 - j1 + one(I)
+    else
+        j_min = j2 - radius
+        width = j1 - j2 + one(I)
+    end
+
+    return Rectangle(Point(i_min, j_min), height + radius2, width + radius2)
+end

--- a/src/point.jl
+++ b/src/point.jl
@@ -12,3 +12,5 @@ end
     put_pixel_inbounds!(image, shape.i, shape.j, color)
     return nothing
 end
+
+get_bounding_box(shape::Point{I}) where {I} = Rectangle(shape, one(I), one(I))

--- a/src/polyline.jl
+++ b/src/polyline.jl
@@ -37,3 +37,41 @@ function draw_inbounds!(image::AbstractMatrix, shape::Polyline, color)
         return nothing
     end
 end
+
+function get_bounding_box(shape::Polyline{I}) where {I}
+    points = shape.points
+    num_points = length(points)
+
+    @assert num_points > 0
+
+    first_point = first(points)
+
+    if num_points == 1
+        return get_bounding_box(first_point)
+    else
+        i_min = first_point.i
+        j_min = first_point.j
+        i_max = first_point.i
+        j_max = first_point.j
+
+        for k in 2 : num_points
+            point = points[k]
+            i = point.i
+            j = point.j
+
+            if i < i_min
+                i_min = i
+            elseif i > i_max
+                i_max = i
+            end
+
+            if j < j_min
+                j_min = j
+            elseif j > j_max
+                j_max = j
+            end
+        end
+
+        return Rectangle(Point(i_min, j_min), i_max - i_min + one(I), j_max - j_min + one(I))
+    end
+end

--- a/src/rectangle.jl
+++ b/src/rectangle.jl
@@ -143,3 +143,7 @@ function draw_inbounds!(image::AbstractMatrix, shape::FilledRectangle, color)
 
     return nothing
 end
+
+get_bounding_box(shape::Rectangle) = shape
+get_bounding_box(shape::ThickRectangle) = Rectangle(shape.top_left, shape.height, shape.width)
+get_bounding_box(shape::FilledRectangle) = Rectangle(shape.top_left, shape.height, shape.width)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -491,6 +491,8 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.Circle(SD.Point(16, 16), 14)
+        bounding_box = SD.get_bounding_box(shape)
+        Test.@test bounding_box == SD.Rectangle(SD.Point(2, 2), 29, 29)
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -532,6 +534,8 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.Circle(SD.Point(24, 24), 14)
+        bounding_box = SD.get_bounding_box(shape)
+        Test.@test bounding_box == SD.Rectangle(SD.Point(10, 10), 29, 29)
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -139,6 +139,8 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.VerticalLine(9, 24, 16)
+        bounding_box = SD.get_bounding_box(shape)
+        Test.@test bounding_box == SD.Rectangle(SD.Point(9, 16), 24 - 9 + 1, 1)
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -180,6 +182,8 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.VerticalLine(-1, 34, 16)
+        bounding_box = SD.get_bounding_box(shape)
+        Test.@test bounding_box == SD.Rectangle(SD.Point(-1, 16), 34 + 1 + 1, 1)
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -227,6 +227,8 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.HorizontalLine(16, 9, 24)
+        bounding_box = SD.get_bounding_box(shape)
+        Test.@test bounding_box == SD.Rectangle(SD.Point(16, 9), 1, 24 - 9 + 1)
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -268,6 +270,8 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.HorizontalLine(16, -1, 34)
+        bounding_box = SD.get_bounding_box(shape)
+        Test.@test bounding_box == SD.Rectangle(SD.Point(16, -1), 1, 34 + 1 + 1)
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1019,6 +1019,8 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.Cross(SD.Point(16, 16), 8)
+        bounding_box = SD.get_bounding_box(shape)
+        Test.@test bounding_box == SD.Rectangle(SD.Point(8, 8), 17, 17)
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -1060,6 +1062,8 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.Cross(SD.Point(28, 28), 8)
+        bounding_box = SD.get_bounding_box(shape)
+        Test.@test bounding_box == SD.Rectangle(SD.Point(20, 20), 17, 17)
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -1103,6 +1107,8 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.HollowCross(SD.Point(16, 16), 8)
+        bounding_box = SD.get_bounding_box(shape)
+        Test.@test bounding_box == SD.Rectangle(SD.Point(8, 8), 17, 17)
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -1144,6 +1150,8 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.HollowCross(SD.Point(28, 28), 8)
+        bounding_box = SD.get_bounding_box(shape)
+        Test.@test bounding_box == SD.Rectangle(SD.Point(20, 20), 17, 17)
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1195,6 +1195,8 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.Polyline([SD.Point(30, 4), SD.Point(24, 30), SD.Point(6, 24), SD.Point(12, 8)])
+        bounding_box = SD.get_bounding_box(shape)
+        Test.@test bounding_box == SD.Rectangle(SD.Point(6, 4), 25, 27)
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -1236,6 +1238,8 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.Polyline([SD.Point(30, 4), SD.Point(24, 40), SD.Point(6, 24), SD.Point(12, 8)])
+        bounding_box = SD.get_bounding_box(shape)
+        Test.@test bounding_box == SD.Rectangle(SD.Point(6, 4), 25, 37)
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -315,6 +315,8 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.Line(SD.Point(9, 5), SD.Point(24, 28))
+        bounding_box = SD.get_bounding_box(shape)
+        Test.@test bounding_box == SD.Rectangle(SD.Point(9, 5), 24 - 9 + 1, 28 - 5 + 1)
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -356,6 +358,8 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.Line(SD.Point(-1, -1), SD.Point(34, 34))
+        bounding_box = SD.get_bounding_box(shape)
+        Test.@test bounding_box == SD.Rectangle(SD.Point(-1, -1), 34 + 1 + 1, 34 + 1 + 1)
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,8 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.Point(16, 16)
+        bounding_box = SD.get_bounding_box(shape)
+        Test.@test bounding_box == SD.Rectangle(shape, 1, 1)
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -49,6 +51,8 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.Point(-1, -1)
+        bounding_box = SD.get_bounding_box(shape)
+        Test.@test bounding_box == SD.Rectangle(shape, 1, 1)
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1283,6 +1283,8 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.Character(SD.Point(1, 1), 'A', SD.TERMINUS_32_16)
+        bounding_box = SD.get_bounding_box(shape)
+        Test.@test bounding_box == SD.Rectangle(SD.Point(1, 1), 32, 16)
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -667,6 +667,8 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.FilledCircle(SD.Point(16, 16), 14)
+        bounding_box = SD.get_bounding_box(shape)
+        Test.@test bounding_box == SD.Rectangle(SD.Point(2, 2), 29, 29)
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -708,6 +710,8 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.FilledCircle(SD.Point(24, 24), 14)
+        bounding_box = SD.get_bounding_box(shape)
+        Test.@test bounding_box == SD.Rectangle(SD.Point(10, 10), 29, 29)
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -579,6 +579,8 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.ThickCircle(SD.Point(16, 16), 14, 5)
+        bounding_box = SD.get_bounding_box(shape)
+        Test.@test bounding_box == SD.Rectangle(SD.Point(2, 2), 29, 29)
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -620,6 +622,8 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.ThickCircle(SD.Point(24, 24), 14, 5)
+        bounding_box = SD.get_bounding_box(shape)
+        Test.@test bounding_box == SD.Rectangle(SD.Point(10, 10), 29, 29)
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -403,6 +403,8 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.ThickLine(SD.Point(9, 5), SD.Point(24, 28), 3)
+        bounding_box = SD.get_bounding_box(shape)
+        Test.@test bounding_box == SD.Rectangle(SD.Point(6, 2), 24 - 9 + 1 + 2 * 3, 28 - 5 + 1 + 2 * 3)
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -444,6 +446,8 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.ThickLine(SD.Point(9, 5), SD.Point(40, 40), 3)
+        bounding_box = SD.get_bounding_box(shape)
+        Test.@test bounding_box == SD.Rectangle(SD.Point(6, 2), 40 - 9 + 1 + 2 * 3, 40 - 5 + 1 + 2 * 3)
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -755,6 +755,8 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.Rectangle(SD.Point(9, 5), 16, 24)
+        bounding_box = SD.get_bounding_box(shape)
+        Test.@test bounding_box == shape
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -796,6 +798,8 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.Rectangle(SD.Point(24, 16), 16, 24)
+        bounding_box = SD.get_bounding_box(shape)
+        Test.@test bounding_box == shape
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -839,6 +843,8 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.ThickRectangle(SD.Point(9, 5), 16, 24, 4)
+        bounding_box = SD.get_bounding_box(shape)
+        Test.@test bounding_box == SD.Rectangle(SD.Point(9, 5), 16, 24)
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -880,6 +886,8 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.ThickRectangle(SD.Point(24, 16), 16, 24, 4)
+        bounding_box = SD.get_bounding_box(shape)
+        Test.@test bounding_box == SD.Rectangle(SD.Point(24, 16), 16, 24)
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -923,6 +931,8 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.FilledRectangle(SD.Point(9, 5), 16, 24)
+        bounding_box = SD.get_bounding_box(shape)
+        Test.@test bounding_box == SD.Rectangle(SD.Point(9, 5), 16, 24)
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -964,6 +974,8 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.FilledRectangle(SD.Point(24, 16), 16, 24)
+        bounding_box = SD.get_bounding_box(shape)
+        Test.@test bounding_box == SD.Rectangle(SD.Point(24, 16), 16, 24)
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([


### PR DESCRIPTION
1. Add `get_bounding_box` methods for all shapes.
2. Add tests for `get_bounding_box` for all shapes.

Fixes #33 