### PR TITLE
resolve corner cases; rename variables; use generics

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,8 @@ This package supports bitmap fonts for [ASCII](https://en.wikipedia.org/wiki/ASC
 
     ```julia
     struct VerticalLine{I <: Integer} <: AbstractShape
-        i_start::I
-        i_end::I
+        i_min::I
+        i_max::I
         j::I
     end
     ```
@@ -175,8 +175,8 @@ This package supports bitmap fonts for [ASCII](https://en.wikipedia.org/wiki/ASC
     ```julia
     struct HorizontalLine{I <: Integer} <: AbstractShape
         i::I
-        j_start::I
-        j_end::I
+        j_min::I
+        j_max::I
     end
     ```
 

--- a/src/SimpleDraw.jl
+++ b/src/SimpleDraw.jl
@@ -4,13 +4,13 @@ abstract type AbstractShape end
 
 @inline function put_pixel!(image, i, j, color)
     if checkbounds(Bool, image, i, j)
-        put_pixel_inbounds!(image, i, j, color)
+        put_pixel_unchecked!(image, i, j, color)
     end
 
     return nothing
 end
 
-@inline function put_pixel_inbounds!(image, i, j, color)
+@inline function put_pixel_unchecked!(image, i, j, color)
     @inbounds image[i, j] = color
     return nothing
 end

--- a/src/background.jl
+++ b/src/background.jl
@@ -1,8 +1,8 @@
 struct Background <: AbstractShape end
 
-@inline draw!(image::AbstractMatrix, shape::Background, color) = draw_inbounds!(image, shape, color)
+@inline draw!(image::AbstractMatrix, shape::Background, color) = draw_unchecked!(image, shape, color)
 
-@inline function draw_inbounds!(image::AbstractMatrix, shape::Background, color)
+@inline function draw_unchecked!(image::AbstractMatrix, shape::Background, color)
     @inbounds image[:, :] .= color
     return nothing
 end

--- a/src/character.jl
+++ b/src/character.jl
@@ -45,7 +45,7 @@ function draw!(image::AbstractMatrix, shape::Character, color)
     return nothing
 end
 
-function draw_inbounds!(image::AbstractMatrix, shape::Character, color)
+function draw_unchecked!(image::AbstractMatrix, shape::Character, color)
     position = shape.position
     char = shape.char
     font = shape.font

--- a/src/character.jl
+++ b/src/character.jl
@@ -36,7 +36,7 @@ function draw!(image::AbstractMatrix, shape::Character, color)
                 i_bitmap = i - position_i + 1
                 j_bitmap = j - position_j + 1
                 if bitmap[i_bitmap, j_bitmap, k]
-                    put_pixel_inbounds!(image, i, j, color)
+                    put_pixel_unchecked!(image, i, j, color)
                 end
             end
         end
@@ -69,7 +69,7 @@ function draw_inbounds!(image::AbstractMatrix, shape::Character, color)
                 i_bitmap = i - position_i + 1
                 j_bitmap = j - position_j + 1
                 if bitmap[i_bitmap, j_bitmap, k]
-                    put_pixel_inbounds!(image, i, j, color)
+                    put_pixel_unchecked!(image, i, j, color)
                 end
             end
         end

--- a/src/character.jl
+++ b/src/character.jl
@@ -12,7 +12,7 @@ struct Character{I, C <: AbstractChar, F <: AbstractFont} <: AbstractShape
     font::F
 end
 
-function draw!(image::AbstractMatrix, shape::Character, color)
+function draw!(image::AbstractMatrix, shape::Character{I}, color) where {I}
     position = shape.position
     char = shape.char
     font = shape.font
@@ -20,15 +20,17 @@ function draw!(image::AbstractMatrix, shape::Character, color)
     position_j = position.j
     bitmap = font.bitmap
 
+    one_value = one(I)
+
     height, width, _ = size(bitmap)
 
     k = codepoint(char) - codepoint('!') + 1
 
     i_min = max(position_i, firstindex(image, 1))
-    i_max = min(position_i + height - 1, lastindex(image, 1))
+    i_max = min(position_i + height - one_value, lastindex(image, 1))
 
     j_min = max(position_j, firstindex(image, 1))
-    j_max = min(position_j + width - 1, lastindex(image, 1))
+    j_max = min(position_j + width - one_value, lastindex(image, 2))
 
     if k in axes(bitmap, 3)
         for j in j_min:j_max

--- a/src/circle.jl
+++ b/src/circle.jl
@@ -177,31 +177,56 @@ function draw_unchecked!(image::AbstractMatrix, shape::Circle{I}, color) where {
 end
 
 function draw!(image::AbstractMatrix, shape::FilledCircle{I}, color) where {I}
-    i_center = shape.center.i
-    j_center = shape.center.j
+    center = shape.center
+    i_center = center.i
+    j_center = center.j
     radius = shape.radius
 
-    if checkbounds(Bool, image, i_center - radius, j_center - radius) && checkbounds(Bool, image, i_center + radius, j_center + radius)
-        draw_unchecked!(image, shape, color)
+    zero_value = zero(I)
+    one_value = one(I)
+
+    if radius <= zero_value
+        return nothing
+    elseif radius == one_value
+        draw!(image, center, color)
         return nothing
     end
 
-    zero_value = zero(I)
+    i_min = i_center - radius
+    j_min = j_center - radius
+
+    i_max = i_center + radius
+    j_max = j_center + radius
+
+    i_min_image = firstindex(image, 1)
+    i_max_image = lastindex(image, 1)
+
+    j_min_image = firstindex(image, 2)
+    j_max_image = lastindex(image, 2)
+
+    if i_max < i_min_image || i_min > i_max_image || j_max < j_min_image || j_min > j_max_image
+        return nothing
+    end
+
+    if i_min >= i_min_image && j_min >= j_min_image && i_max <= i_max_image && j_max <= j_max_image
+        draw_unchecked!(image, shape, color)
+        return nothing
+    end
 
     i = zero_value
     j = radius
 
     draw_vertical_strip_reflections!(image, i_center, j_center, i, j, color)
 
-    constant = 3 - 2 * radius * radius
+    constant = convert(I, 3) - convert(I, 2) * radius * radius
 
     while j >= i
-        d = 2 * j * j + 2 * i * i + 4 * i - 2 * j + constant
+        d = convert(I, 2) * j * j + convert(I, 2) * i * i + convert(I, 4) * i - convert(I, 2) * j + constant
 
-        i += 1
+        i += one_value
 
         if d > zero_value
-            j -= 1
+            j -= one_value
         end
 
         draw_vertical_strip_reflections!(image, i_center, j_center, i, j, color)
@@ -216,21 +241,22 @@ function draw_unchecked!(image::AbstractMatrix, shape::FilledCircle{I}, color) w
     radius = shape.radius
 
     zero_value = zero(I)
+    one_value = one(I)
 
     i = zero_value
     j = radius
 
     draw_vertical_strip_reflections_unchecked!(image, i_center, j_center, i, j, color)
 
-    constant = 3 - 2 * radius * radius
+    constant = convert(I, 3) - convert(I, 2) * radius * radius
 
     while j >= i
-        d = 2 * j * j + 2 * i * i + 4 * i - 2 * j + constant
+        d = convert(I, 2) * j * j + convert(I, 2) * i * i + convert(I, 4) * i - convert(I, 2) * j + constant
 
-        i += 1
+        i += one_value
 
         if d > zero_value
-            j -= 1
+            j -= one_value
         end
 
         draw_vertical_strip_reflections_unchecked!(image, i_center, j_center, i, j, color)

--- a/src/circle.jl
+++ b/src/circle.jl
@@ -271,14 +271,46 @@ function draw!(image::AbstractMatrix, shape::ThickCircle{I}, color) where {I}
     j_center = center.j
     radius_outer = shape.radius
     thickness = shape.thickness
-    radius_inner = radius_outer - thickness + 1
 
-    if checkbounds(Bool, image, i_center - radius_outer, j_center - radius_outer) && checkbounds(Bool, image, i_center + radius_outer, j_center + radius_outer)
+    zero_value = zero(I)
+    one_value = one(I)
+
+    if thickness < one_value || thickness > radius_outer || radius_outer < one_value
+        return nothing
+    end
+
+    i_min = i_center - radius_outer
+    j_min = j_center - radius_outer
+
+    i_max = i_center + radius_outer
+    j_max = j_center + radius_outer
+
+    i_min_image = firstindex(image, 1)
+    i_max_image = lastindex(image, 1)
+
+    j_min_image = firstindex(image, 2)
+    j_max_image = lastindex(image, 2)
+
+    if i_max < i_min_image || i_min > i_max_image || j_max < j_min_image || j_min > j_max_image
+        return nothing
+    end
+
+    if thickness == one_value
+        draw!(image, Circle(center, radius_outer), color)
+        return nothing
+    end
+
+    if thickness == radius_outer
+        draw!(image, FilledCircle(center, radius_outer), color)
+        return nothing
+    end
+
+    if i_min >= i_min_image && j_min >= j_min_image && i_max <= i_max_image && j_max <= j_max_image
         draw_unchecked!(image, shape, color)
         return nothing
     end
 
-    zero_value = zero(I)
+    radius_inner = radius_outer - thickness + one_value
 
     i_inner = zero_value
     j_inner = radius_inner
@@ -288,34 +320,34 @@ function draw!(image::AbstractMatrix, shape::ThickCircle{I}, color) where {I}
 
     draw_octant_reflections_lines!(image, i_center, j_center, i_outer, j_inner, j_outer, color)
 
-    constant_inner = 3 - 2 * radius_inner * radius_inner
-    constant_outer = 3 - 2 * radius_outer * radius_outer
+    constant_inner = convert(I, 3) - convert(I, 2) * radius_inner * radius_inner
+    constant_outer = convert(I, 3) - convert(I, 2) * radius_outer * radius_outer
 
     while j_inner >= i_inner
-        d_inner = 2 * j_inner * j_inner + 2 * i_inner * i_inner + 4 * i_inner - 2 * j_inner + constant_inner
-        d_outer = 2 * j_outer * j_outer + 2 * i_outer * i_outer + 4 * i_outer - 2 * j_outer + constant_outer
+        d_inner = convert(I, 2) * j_inner * j_inner + convert(I, 2) * i_inner * i_inner + convert(I, 4) * i_inner - convert(I, 2) * j_inner + constant_inner
+        d_outer = convert(I, 2) * j_outer * j_outer + convert(I, 2) * i_outer * i_outer + convert(I, 4) * i_outer - convert(I, 2) * j_outer + constant_outer
 
-        i_inner += 1
-        i_outer += 1
+        i_inner += one_value
+        i_outer += one_value
 
         if d_inner > zero_value
-            j_inner -= 1
+            j_inner -= one_value
         end
 
         if d_outer > zero_value
-            j_outer -= 1
+            j_outer -= one_value
         end
 
         draw_octant_reflections_lines!(image, i_center, j_center, i_outer, j_inner, j_outer, color)
     end
 
     while j_outer >= i_outer
-        d_outer = 2 * j_outer * j_outer + 2 * i_outer * i_outer + 4 * i_outer - 2 * j_outer + constant_outer
+        d_outer = convert(I, 2) * j_outer * j_outer + convert(I, 2) * i_outer * i_outer + convert(I, 4) * i_outer - convert(I, 2) * j_outer + constant_outer
 
-        i_outer += 1
+        i_outer += one_value
 
         if d_outer > zero_value
-            j_outer -= 1
+            j_outer -= one_value
         end
 
         i = min(i_outer, j_outer)
@@ -335,6 +367,9 @@ function draw_unchecked!(image::AbstractMatrix, shape::ThickCircle{I}, color) wh
     radius_inner = radius_outer - thickness + 1
 
     zero_value = zero(I)
+    one_value = one(I)
+
+    radius_inner = radius_outer - thickness + one_value
 
     i_inner = zero_value
     j_inner = radius_inner
@@ -344,34 +379,34 @@ function draw_unchecked!(image::AbstractMatrix, shape::ThickCircle{I}, color) wh
 
     draw_octant_reflections_lines_unchecked!(image, i_center, j_center, i_outer, j_inner, j_outer, color)
 
-    constant_inner = 3 - 2 * radius_inner * radius_inner
-    constant_outer = 3 - 2 * radius_outer * radius_outer
+    constant_inner = convert(I, 3) - convert(I, 2) * radius_inner * radius_inner
+    constant_outer = convert(I, 3) - convert(I, 2) * radius_outer * radius_outer
 
     while j_inner >= i_inner
-        d_inner = 2 * j_inner * j_inner + 2 * i_inner * i_inner + 4 * i_inner - 2 * j_inner + constant_inner
-        d_outer = 2 * j_outer * j_outer + 2 * i_outer * i_outer + 4 * i_outer - 2 * j_outer + constant_outer
+        d_inner = convert(I, 2) * j_inner * j_inner + convert(I, 2) * i_inner * i_inner + convert(I, 4) * i_inner - convert(I, 2) * j_inner + constant_inner
+        d_outer = convert(I, 2) * j_outer * j_outer + convert(I, 2) * i_outer * i_outer + convert(I, 4) * i_outer - convert(I, 2) * j_outer + constant_outer
 
-        i_inner += 1
-        i_outer += 1
+        i_inner += one_value
+        i_outer += one_value
 
         if d_inner > zero_value
-            j_inner -= 1
+            j_inner -= one_value
         end
 
         if d_outer > zero_value
-            j_outer -= 1
+            j_outer -= one_value
         end
 
         draw_octant_reflections_lines_unchecked!(image, i_center, j_center, i_outer, j_inner, j_outer, color)
     end
 
     while j_outer >= i_outer
-        d_outer = 2 * j_outer * j_outer + 2 * i_outer * i_outer + 4 * i_outer - 2 * j_outer + constant_outer
+        d_outer = convert(I, 2) * j_outer * j_outer + convert(I, 2) * i_outer * i_outer + convert(I, 4) * i_outer - convert(I, 2) * j_outer + constant_outer
 
-        i_outer += 1
+        i_outer += one_value
 
         if d_outer > zero_value
-            j_outer -= 1
+            j_outer -= one_value
         end
 
         i = min(i_outer, j_outer)

--- a/src/circle.jl
+++ b/src/circle.jl
@@ -88,31 +88,56 @@ end
 Draw a circle. Ref: https://en.wikipedia.org/wiki/Midpoint_circle_algorithm variant with integer-based arithmetic
 """
 function draw!(image::AbstractMatrix, shape::Circle{I}, color) where {I}
-    i_center = shape.center.i
-    j_center = shape.center.j
+    center = shape.center
+    i_center = center.i
+    j_center = center.j
     radius = shape.radius
 
-    if checkbounds(Bool, image, i_center - radius, j_center - radius) && checkbounds(Bool, image, i_center + radius, j_center + radius)
-        draw_unchecked!(image, shape, color)
+    zero_value = zero(I)
+    one_value = one(I)
+
+    if radius <= zero_value
+        return nothing
+    elseif radius == one_value
+        draw!(image, center, color)
         return nothing
     end
 
-    zero_value = zero(I)
+    i_min = i_center - radius
+    j_min = j_center - radius
+
+    i_max = i_center + radius
+    j_max = j_center + radius
+
+    i_min_image = firstindex(image, 1)
+    i_max_image = lastindex(image, 1)
+
+    j_min_image = firstindex(image, 2)
+    j_max_image = lastindex(image, 2)
+
+    if i_max < i_min_image || i_min > i_max_image || j_max < j_min_image || j_min > j_max_image
+        return nothing
+    end
+
+    if i_min >= i_min_image && j_min >= j_min_image && i_max <= i_max_image && j_max <= j_max_image
+        draw_unchecked!(image, shape, color)
+        return nothing
+    end
 
     i = zero_value
     j = radius
 
     draw_octant_reflections!(image, i_center, j_center, i, j, color)
 
-    constant = 3 - 2 * radius * radius
+    constant = convert(I, 3) - convert(I, 2) * radius * radius
 
     while j >= i
-        d = 2 * j * j + 2 * i * i + 4 * i - 2 * j + constant
+        d = convert(I, 2) * j * j + convert(I, 2) * i * i + convert(I, 4) * i - convert(I, 2) * j + constant
 
-        i += 1
+        i += one_value
 
         if d > zero_value
-            j -= 1
+            j -= one_value
         end
 
         draw_octant_reflections!(image, i_center, j_center, i, j, color)
@@ -127,21 +152,22 @@ function draw_unchecked!(image::AbstractMatrix, shape::Circle{I}, color) where {
     radius = shape.radius
 
     zero_value = zero(I)
+    one_value = one(I)
 
     i = zero_value
     j = radius
 
     draw_octant_reflections_unchecked!(image, i_center, j_center, i, j, color)
 
-    constant = 3 - 2 * radius * radius
+    constant = convert(I, 3) - convert(I, 2) * radius * radius
 
     while j >= i
-        d = 2 * j * j + 2 * i * i + 4 * i - 2 * j + constant
+        d = convert(I, 2) * j * j + convert(I, 2) * i * i + convert(I, 4) * i - convert(I, 2) * j + constant
 
-        i += 1
+        i += one_value
 
         if d > zero_value
-            j -= 1
+            j -= one_value
         end
 
         draw_octant_reflections_unchecked!(image, i_center, j_center, i, j, color)

--- a/src/circle.jl
+++ b/src/circle.jl
@@ -96,10 +96,7 @@ function draw!(image::AbstractMatrix, shape::Circle{I}, color) where {I}
     zero_value = zero(I)
     one_value = one(I)
 
-    if radius <= zero_value
-        return nothing
-    elseif radius == one_value
-        draw!(image, center, color)
+    if radius < zero_value
         return nothing
     end
 
@@ -116,6 +113,11 @@ function draw!(image::AbstractMatrix, shape::Circle{I}, color) where {I}
     j_max_image = lastindex(image, 2)
 
     if i_max < i_min_image || i_min > i_max_image || j_max < j_min_image || j_min > j_max_image
+        return nothing
+    end
+
+    if radius == zero_value
+        draw!(image, center, color)
         return nothing
     end
 
@@ -185,10 +187,7 @@ function draw!(image::AbstractMatrix, shape::FilledCircle{I}, color) where {I}
     zero_value = zero(I)
     one_value = one(I)
 
-    if radius <= zero_value
-        return nothing
-    elseif radius == one_value
-        draw!(image, center, color)
+    if radius < zero_value
         return nothing
     end
 
@@ -205,6 +204,11 @@ function draw!(image::AbstractMatrix, shape::FilledCircle{I}, color) where {I}
     j_max_image = lastindex(image, 2)
 
     if i_max < i_min_image || i_min > i_max_image || j_max < j_min_image || j_min > j_max_image
+        return nothing
+    end
+
+    if radius == zero_value
+        draw!(image, center, color)
         return nothing
     end
 
@@ -275,7 +279,7 @@ function draw!(image::AbstractMatrix, shape::ThickCircle{I}, color) where {I}
     zero_value = zero(I)
     one_value = one(I)
 
-    if thickness < one_value || thickness > radius_outer || radius_outer < one_value
+    if thickness < one_value || thickness > radius_outer || radius_outer < zero_value
         return nothing
     end
 
@@ -292,6 +296,11 @@ function draw!(image::AbstractMatrix, shape::ThickCircle{I}, color) where {I}
     j_max_image = lastindex(image, 2)
 
     if i_max < i_min_image || i_min > i_max_image || j_max < j_min_image || j_min > j_max_image
+        return nothing
+    end
+
+    if radius_outer == zero_value
+        draw!(image, center, color)
         return nothing
     end
 
@@ -364,7 +373,6 @@ function draw_unchecked!(image::AbstractMatrix, shape::ThickCircle{I}, color) wh
     j_center = center.j
     radius_outer = shape.radius
     thickness = shape.thickness
-    radius_inner = radius_outer - thickness + 1
 
     zero_value = zero(I)
     one_value = one(I)

--- a/src/circle.jl
+++ b/src/circle.jl
@@ -46,14 +46,14 @@ end
 end
 
 @inline function draw_octant_reflections_inbounds!(image::AbstractMatrix, i_center, j_center, i, j, color)
-    put_pixel_inbounds!(image, i_center - i, j_center - j, color)
-    put_pixel_inbounds!(image, i_center + i, j_center - j, color)
-    put_pixel_inbounds!(image, i_center - j, j_center - i, color)
-    put_pixel_inbounds!(image, i_center + j, j_center - i, color)
-    put_pixel_inbounds!(image, i_center - j, j_center + i, color)
-    put_pixel_inbounds!(image, i_center + j, j_center + i, color)
-    put_pixel_inbounds!(image, i_center - i, j_center + j, color)
-    put_pixel_inbounds!(image, i_center + i, j_center + j, color)
+    put_pixel_unchecked!(image, i_center - i, j_center - j, color)
+    put_pixel_unchecked!(image, i_center + i, j_center - j, color)
+    put_pixel_unchecked!(image, i_center - j, j_center - i, color)
+    put_pixel_unchecked!(image, i_center + j, j_center - i, color)
+    put_pixel_unchecked!(image, i_center - j, j_center + i, color)
+    put_pixel_unchecked!(image, i_center + j, j_center + i, color)
+    put_pixel_unchecked!(image, i_center - i, j_center + j, color)
+    put_pixel_unchecked!(image, i_center + i, j_center + j, color)
 
     return nothing
 end

--- a/src/circle.jl
+++ b/src/circle.jl
@@ -23,7 +23,7 @@ end
     return nothing
 end
 
-@inline function draw_vertical_strip_reflections_inbounds!(image::AbstractMatrix, i_center::Integer, j_center::Integer, i::Integer, j::Integer, color)
+@inline function draw_vertical_strip_reflections_unchecked!(image::AbstractMatrix, i_center::Integer, j_center::Integer, i::Integer, j::Integer, color)
     draw_unchecked!(image, VerticalLine(i_center - i, i_center + i, j_center - j), color)
     draw_unchecked!(image, VerticalLine(i_center - j, i_center + j, j_center - i), color)
     draw_unchecked!(image, VerticalLine(i_center - j, i_center + j, j_center + i), color)
@@ -45,7 +45,7 @@ end
     return nothing
 end
 
-@inline function draw_octant_reflections_inbounds!(image::AbstractMatrix, i_center, j_center, i, j, color)
+@inline function draw_octant_reflections_unchecked!(image::AbstractMatrix, i_center, j_center, i, j, color)
     put_pixel_unchecked!(image, i_center - i, j_center - j, color)
     put_pixel_unchecked!(image, i_center + i, j_center - j, color)
     put_pixel_unchecked!(image, i_center - j, j_center - i, color)
@@ -71,7 +71,7 @@ end
     return nothing
 end
 
-@inline function draw_octant_reflections_lines_inbounds!(image::AbstractMatrix, i_center, j_center, i, j_inner, j_outer, color)
+@inline function draw_octant_reflections_lines_unchecked!(image::AbstractMatrix, i_center, j_center, i, j_inner, j_outer, color)
     draw_unchecked!(image, HorizontalLine(i_center - i, j_center - j_outer, j_center - j_inner), color)
     draw_unchecked!(image, HorizontalLine(i_center + i, j_center - j_outer, j_center - j_inner), color)
     draw_unchecked!(image, VerticalLine(i_center - j_outer, i_center - j_inner, j_center - i), color)
@@ -131,7 +131,7 @@ function draw_unchecked!(image::AbstractMatrix, shape::Circle{I}, color) where {
     i = zero_value
     j = radius
 
-    draw_octant_reflections_inbounds!(image, i_center, j_center, i, j, color)
+    draw_octant_reflections_unchecked!(image, i_center, j_center, i, j, color)
 
     constant = 3 - 2 * radius * radius
 
@@ -144,7 +144,7 @@ function draw_unchecked!(image::AbstractMatrix, shape::Circle{I}, color) where {
             j -= 1
         end
 
-        draw_octant_reflections_inbounds!(image, i_center, j_center, i, j, color)
+        draw_octant_reflections_unchecked!(image, i_center, j_center, i, j, color)
     end
 
     return nothing
@@ -194,7 +194,7 @@ function draw_unchecked!(image::AbstractMatrix, shape::FilledCircle{I}, color) w
     i = zero_value
     j = radius
 
-    draw_vertical_strip_reflections_inbounds!(image, i_center, j_center, i, j, color)
+    draw_vertical_strip_reflections_unchecked!(image, i_center, j_center, i, j, color)
 
     constant = 3 - 2 * radius * radius
 
@@ -207,7 +207,7 @@ function draw_unchecked!(image::AbstractMatrix, shape::FilledCircle{I}, color) w
             j -= 1
         end
 
-        draw_vertical_strip_reflections_inbounds!(image, i_center, j_center, i, j, color)
+        draw_vertical_strip_reflections_unchecked!(image, i_center, j_center, i, j, color)
     end
 
     return nothing
@@ -290,7 +290,7 @@ function draw_unchecked!(image::AbstractMatrix, shape::ThickCircle{I}, color) wh
     i_outer = zero_value
     j_outer = radius_outer
 
-    draw_octant_reflections_lines_inbounds!(image, i_center, j_center, i_outer, j_inner, j_outer, color)
+    draw_octant_reflections_lines_unchecked!(image, i_center, j_center, i_outer, j_inner, j_outer, color)
 
     constant_inner = 3 - 2 * radius_inner * radius_inner
     constant_outer = 3 - 2 * radius_outer * radius_outer
@@ -310,7 +310,7 @@ function draw_unchecked!(image::AbstractMatrix, shape::ThickCircle{I}, color) wh
             j_outer -= 1
         end
 
-        draw_octant_reflections_lines_inbounds!(image, i_center, j_center, i_outer, j_inner, j_outer, color)
+        draw_octant_reflections_lines_unchecked!(image, i_center, j_center, i_outer, j_inner, j_outer, color)
     end
 
     while j_outer >= i_outer
@@ -324,7 +324,7 @@ function draw_unchecked!(image::AbstractMatrix, shape::ThickCircle{I}, color) wh
 
         i = min(i_outer, j_outer)
 
-        draw_octant_reflections_lines_inbounds!(image, i_center, j_center, i, i_outer, j_outer, color)
+        draw_octant_reflections_lines_unchecked!(image, i_center, j_center, i, i_outer, j_outer, color)
     end
 
     return nothing

--- a/src/circle.jl
+++ b/src/circle.jl
@@ -24,10 +24,10 @@ end
 end
 
 @inline function draw_vertical_strip_reflections_inbounds!(image::AbstractMatrix, i_center::Integer, j_center::Integer, i::Integer, j::Integer, color)
-    draw_inbounds!(image, VerticalLine(i_center - i, i_center + i, j_center - j), color)
-    draw_inbounds!(image, VerticalLine(i_center - j, i_center + j, j_center - i), color)
-    draw_inbounds!(image, VerticalLine(i_center - j, i_center + j, j_center + i), color)
-    draw_inbounds!(image, VerticalLine(i_center - i, i_center + i, j_center + j), color)
+    draw_unchecked!(image, VerticalLine(i_center - i, i_center + i, j_center - j), color)
+    draw_unchecked!(image, VerticalLine(i_center - j, i_center + j, j_center - i), color)
+    draw_unchecked!(image, VerticalLine(i_center - j, i_center + j, j_center + i), color)
+    draw_unchecked!(image, VerticalLine(i_center - i, i_center + i, j_center + j), color)
 
     return nothing
 end
@@ -72,14 +72,14 @@ end
 end
 
 @inline function draw_octant_reflections_lines_inbounds!(image::AbstractMatrix, i_center, j_center, i, j_inner, j_outer, color)
-    draw_inbounds!(image, HorizontalLine(i_center - i, j_center - j_outer, j_center - j_inner), color)
-    draw_inbounds!(image, HorizontalLine(i_center + i, j_center - j_outer, j_center - j_inner), color)
-    draw_inbounds!(image, VerticalLine(i_center - j_outer, i_center - j_inner, j_center - i), color)
-    draw_inbounds!(image, VerticalLine(i_center + j_inner, i_center + j_outer, j_center - i), color)
-    draw_inbounds!(image, VerticalLine(i_center - j_outer, i_center - j_inner, j_center + i), color)
-    draw_inbounds!(image, VerticalLine(i_center + j_inner, i_center + j_outer, j_center + i), color)
-    draw_inbounds!(image, HorizontalLine(i_center - i, j_center + j_inner, j_center + j_outer), color)
-    draw_inbounds!(image, HorizontalLine(i_center + i, j_center + j_inner, j_center + j_outer), color)
+    draw_unchecked!(image, HorizontalLine(i_center - i, j_center - j_outer, j_center - j_inner), color)
+    draw_unchecked!(image, HorizontalLine(i_center + i, j_center - j_outer, j_center - j_inner), color)
+    draw_unchecked!(image, VerticalLine(i_center - j_outer, i_center - j_inner, j_center - i), color)
+    draw_unchecked!(image, VerticalLine(i_center + j_inner, i_center + j_outer, j_center - i), color)
+    draw_unchecked!(image, VerticalLine(i_center - j_outer, i_center - j_inner, j_center + i), color)
+    draw_unchecked!(image, VerticalLine(i_center + j_inner, i_center + j_outer, j_center + i), color)
+    draw_unchecked!(image, HorizontalLine(i_center - i, j_center + j_inner, j_center + j_outer), color)
+    draw_unchecked!(image, HorizontalLine(i_center + i, j_center + j_inner, j_center + j_outer), color)
 
     return nothing
 end
@@ -93,7 +93,7 @@ function draw!(image::AbstractMatrix, shape::Circle{I}, color) where {I}
     radius = shape.radius
 
     if checkbounds(Bool, image, i_center - radius, j_center - radius) && checkbounds(Bool, image, i_center + radius, j_center + radius)
-        draw_inbounds!(image, shape, color)
+        draw_unchecked!(image, shape, color)
         return nothing
     end
 
@@ -121,7 +121,7 @@ function draw!(image::AbstractMatrix, shape::Circle{I}, color) where {I}
     return nothing
 end
 
-function draw_inbounds!(image::AbstractMatrix, shape::Circle{I}, color) where {I}
+function draw_unchecked!(image::AbstractMatrix, shape::Circle{I}, color) where {I}
     i_center = shape.center.i
     j_center = shape.center.j
     radius = shape.radius
@@ -156,7 +156,7 @@ function draw!(image::AbstractMatrix, shape::FilledCircle{I}, color) where {I}
     radius = shape.radius
 
     if checkbounds(Bool, image, i_center - radius, j_center - radius) && checkbounds(Bool, image, i_center + radius, j_center + radius)
-        draw_inbounds!(image, shape, color)
+        draw_unchecked!(image, shape, color)
         return nothing
     end
 
@@ -184,7 +184,7 @@ function draw!(image::AbstractMatrix, shape::FilledCircle{I}, color) where {I}
     return nothing
 end
 
-function draw_inbounds!(image::AbstractMatrix, shape::FilledCircle{I}, color) where {I}
+function draw_unchecked!(image::AbstractMatrix, shape::FilledCircle{I}, color) where {I}
     i_center = shape.center.i
     j_center = shape.center.j
     radius = shape.radius
@@ -222,7 +222,7 @@ function draw!(image::AbstractMatrix, shape::ThickCircle{I}, color) where {I}
     radius_inner = radius_outer - thickness + 1
 
     if checkbounds(Bool, image, i_center - radius_outer, j_center - radius_outer) && checkbounds(Bool, image, i_center + radius_outer, j_center + radius_outer)
-        draw_inbounds!(image, shape, color)
+        draw_unchecked!(image, shape, color)
         return nothing
     end
 
@@ -274,7 +274,7 @@ function draw!(image::AbstractMatrix, shape::ThickCircle{I}, color) where {I}
     return nothing
 end
 
-function draw_inbounds!(image::AbstractMatrix, shape::ThickCircle{I}, color) where {I}
+function draw_unchecked!(image::AbstractMatrix, shape::ThickCircle{I}, color) where {I}
     center = shape.center
     i_center = center.i
     j_center = center.j

--- a/src/cross.jl
+++ b/src/cross.jl
@@ -14,19 +14,19 @@ function draw!(image::AbstractMatrix, shape::Cross, color)
     j_center = center.j
     radius = shape.radius
 
-    i_start = i_center - radius
-    i_end = i_center + radius
+    i_min = i_center - radius
+    i_max = i_center + radius
 
-    j_start = j_center - radius
-    j_end = j_center + radius
+    j_min = j_center - radius
+    j_max = j_center + radius
 
-    if checkbounds(Bool, image, i_start, j_start) && checkbounds(Bool, image, i_end, j_end)
+    if checkbounds(Bool, image, i_min, j_min) && checkbounds(Bool, image, i_max, j_max)
         draw_unchecked!(image, shape, color)
         return nothing
     end
 
-    draw!(image, HorizontalLine(i_center, j_start, j_end), color)
-    draw!(image, VerticalLine(i_start, i_end, j_center), color)
+    draw!(image, HorizontalLine(i_center, j_min, j_max), color)
+    draw!(image, VerticalLine(i_min, i_max, j_center), color)
 
     return nothing
 end
@@ -49,21 +49,21 @@ function draw!(image::AbstractMatrix, shape::HollowCross, color)
     j_center = center.j
     radius = shape.radius
 
-    i_start = i_center - radius
-    i_end = i_center + radius
+    i_min = i_center - radius
+    i_max = i_center + radius
 
-    j_start = j_center - radius
-    j_end = j_center + radius
+    j_min = j_center - radius
+    j_max = j_center + radius
 
-    if checkbounds(Bool, image, i_start, j_start) && checkbounds(Bool, image, i_end, j_end)
+    if checkbounds(Bool, image, i_min, j_min) && checkbounds(Bool, image, i_max, j_max)
         draw_unchecked!(image, shape, color)
         return nothing
     end
 
-    draw!(image, HorizontalLine(i_center, j_start, j_center - 1), color)
-    draw!(image, VerticalLine(i_start, i_center - 1, j_center), color)
-    draw!(image, VerticalLine(i_center + 1, i_end, j_center), color)
-    draw!(image, HorizontalLine(i_center, j_center + 1, j_end), color)
+    draw!(image, HorizontalLine(i_center, j_min, j_center - 1), color)
+    draw!(image, VerticalLine(i_min, i_center - 1, j_center), color)
+    draw!(image, VerticalLine(i_center + 1, i_max, j_center), color)
+    draw!(image, HorizontalLine(i_center, j_center + 1, j_max), color)
 
     return nothing
 end
@@ -74,16 +74,16 @@ function draw_unchecked!(image::AbstractMatrix, shape::HollowCross, color)
     j_center = center.j
     radius = shape.radius
 
-    i_start = i_center - radius
-    i_end = i_center + radius
+    i_min = i_center - radius
+    i_max = i_center + radius
 
-    j_start = j_center - radius
-    j_end = j_center + radius
+    j_min = j_center - radius
+    j_max = j_center + radius
 
-    draw_unchecked!(image, HorizontalLine(i_center, j_start, j_center - 1), color)
-    draw_unchecked!(image, VerticalLine(i_start, i_center - 1, j_center), color)
-    draw_unchecked!(image, VerticalLine(i_center + 1, i_end, j_center), color)
-    draw_unchecked!(image, HorizontalLine(i_center, j_center + 1, j_end), color)
+    draw_unchecked!(image, HorizontalLine(i_center, j_min, j_center - 1), color)
+    draw_unchecked!(image, VerticalLine(i_min, i_center - 1, j_center), color)
+    draw_unchecked!(image, VerticalLine(i_center + 1, i_max, j_center), color)
+    draw_unchecked!(image, HorizontalLine(i_center, j_center + 1, j_max), color)
 
     return nothing
 end

--- a/src/cross.jl
+++ b/src/cross.jl
@@ -21,7 +21,7 @@ function draw!(image::AbstractMatrix, shape::Cross, color)
     j_end = j_center + radius
 
     if checkbounds(Bool, image, i_start, j_start) && checkbounds(Bool, image, i_end, j_end)
-        draw_inbounds!(image, shape, color)
+        draw_unchecked!(image, shape, color)
         return nothing
     end
 
@@ -31,14 +31,14 @@ function draw!(image::AbstractMatrix, shape::Cross, color)
     return nothing
 end
 
-function draw_inbounds!(image::AbstractMatrix, shape::Cross, color)
+function draw_unchecked!(image::AbstractMatrix, shape::Cross, color)
     center = shape.center
     i_center = center.i
     j_center = center.j
     radius = shape.radius
 
-    draw_inbounds!(image, HorizontalLine(i_center, j_center - radius, j_center + radius), color)
-    draw_inbounds!(image, VerticalLine(i_center - radius, i_center + radius, j_center), color)
+    draw_unchecked!(image, HorizontalLine(i_center, j_center - radius, j_center + radius), color)
+    draw_unchecked!(image, VerticalLine(i_center - radius, i_center + radius, j_center), color)
 
     return nothing
 end
@@ -56,7 +56,7 @@ function draw!(image::AbstractMatrix, shape::HollowCross, color)
     j_end = j_center + radius
 
     if checkbounds(Bool, image, i_start, j_start) && checkbounds(Bool, image, i_end, j_end)
-        draw_inbounds!(image, shape, color)
+        draw_unchecked!(image, shape, color)
         return nothing
     end
 
@@ -68,7 +68,7 @@ function draw!(image::AbstractMatrix, shape::HollowCross, color)
     return nothing
 end
 
-function draw_inbounds!(image::AbstractMatrix, shape::HollowCross, color)
+function draw_unchecked!(image::AbstractMatrix, shape::HollowCross, color)
     center = shape.center
     i_center = center.i
     j_center = center.j
@@ -80,10 +80,10 @@ function draw_inbounds!(image::AbstractMatrix, shape::HollowCross, color)
     j_start = j_center - radius
     j_end = j_center + radius
 
-    draw_inbounds!(image, HorizontalLine(i_center, j_start, j_center - 1), color)
-    draw_inbounds!(image, VerticalLine(i_start, i_center - 1, j_center), color)
-    draw_inbounds!(image, VerticalLine(i_center + 1, i_end, j_center), color)
-    draw_inbounds!(image, HorizontalLine(i_center, j_center + 1, j_end), color)
+    draw_unchecked!(image, HorizontalLine(i_center, j_start, j_center - 1), color)
+    draw_unchecked!(image, VerticalLine(i_start, i_center - 1, j_center), color)
+    draw_unchecked!(image, VerticalLine(i_center + 1, i_end, j_center), color)
+    draw_unchecked!(image, HorizontalLine(i_center, j_center + 1, j_end), color)
 
     return nothing
 end

--- a/src/cross.jl
+++ b/src/cross.jl
@@ -8,19 +8,41 @@ struct HollowCross{I <: Integer} <: AbstractShape
     radius::I
 end
 
-function draw!(image::AbstractMatrix, shape::Cross, color)
+function draw!(image::AbstractMatrix, shape::Cross{I}, color) where {I}
     center = shape.center
     i_center = center.i
     j_center = center.j
     radius = shape.radius
 
-    i_min = i_center - radius
-    i_max = i_center + radius
+    zero_value = zero(I)
+    one_value = one(I)
 
+    if radius < zero_value
+        return nothing
+    end
+
+    i_min = i_center - radius
     j_min = j_center - radius
+
+    i_max = i_center + radius
     j_max = j_center + radius
 
-    if checkbounds(Bool, image, i_min, j_min) && checkbounds(Bool, image, i_max, j_max)
+    i_min_image = firstindex(image, 1)
+    i_max_image = lastindex(image, 1)
+
+    j_min_image = firstindex(image, 2)
+    j_max_image = lastindex(image, 2)
+
+    if i_max < i_min_image || i_min > i_max_image || j_max < j_min_image || j_min > j_max_image
+        return nothing
+    end
+
+    if radius == zero_value
+        draw!(image, center, color)
+        return nothing
+    end
+
+    if i_min >= i_min_image && j_min >= j_min_image && i_max <= i_max_image && j_max <= j_max_image
         draw_unchecked!(image, shape, color)
         return nothing
     end
@@ -43,36 +65,55 @@ function draw_unchecked!(image::AbstractMatrix, shape::Cross, color)
     return nothing
 end
 
-function draw!(image::AbstractMatrix, shape::HollowCross, color)
+function draw!(image::AbstractMatrix, shape::HollowCross{I}, color) where {I}
     center = shape.center
     i_center = center.i
     j_center = center.j
     radius = shape.radius
 
-    i_min = i_center - radius
-    i_max = i_center + radius
+    zero_value = zero(I)
+    one_value = one(I)
 
+    if radius < one_value
+        return nothing
+    end
+
+    i_min = i_center - radius
     j_min = j_center - radius
+
+    i_max = i_center + radius
     j_max = j_center + radius
 
-    if checkbounds(Bool, image, i_min, j_min) && checkbounds(Bool, image, i_max, j_max)
+    i_min_image = firstindex(image, 1)
+    i_max_image = lastindex(image, 1)
+
+    j_min_image = firstindex(image, 2)
+    j_max_image = lastindex(image, 2)
+
+    if i_max < i_min_image || i_min > i_max_image || j_max < j_min_image || j_min > j_max_image
+        return nothing
+    end
+
+    if i_min >= i_min_image && j_min >= j_min_image && i_max <= i_max_image && j_max <= j_max_image
         draw_unchecked!(image, shape, color)
         return nothing
     end
 
-    draw!(image, HorizontalLine(i_center, j_min, j_center - 1), color)
-    draw!(image, VerticalLine(i_min, i_center - 1, j_center), color)
-    draw!(image, VerticalLine(i_center + 1, i_max, j_center), color)
-    draw!(image, HorizontalLine(i_center, j_center + 1, j_max), color)
+    draw!(image, HorizontalLine(i_center, j_min, j_center - one_value), color)
+    draw!(image, VerticalLine(i_min, i_center - one_value, j_center), color)
+    draw!(image, VerticalLine(i_center + one_value, i_max, j_center), color)
+    draw!(image, HorizontalLine(i_center, j_center + one_value, j_max), color)
 
     return nothing
 end
 
-function draw_unchecked!(image::AbstractMatrix, shape::HollowCross, color)
+function draw_unchecked!(image::AbstractMatrix, shape::HollowCross{I}, color) where {I}
     center = shape.center
     i_center = center.i
     j_center = center.j
     radius = shape.radius
+
+    one_value = one(I)
 
     i_min = i_center - radius
     i_max = i_center + radius
@@ -80,10 +121,10 @@ function draw_unchecked!(image::AbstractMatrix, shape::HollowCross, color)
     j_min = j_center - radius
     j_max = j_center + radius
 
-    draw_unchecked!(image, HorizontalLine(i_center, j_min, j_center - 1), color)
-    draw_unchecked!(image, VerticalLine(i_min, i_center - 1, j_center), color)
-    draw_unchecked!(image, VerticalLine(i_center + 1, i_max, j_center), color)
-    draw_unchecked!(image, HorizontalLine(i_center, j_center + 1, j_max), color)
+    draw_unchecked!(image, HorizontalLine(i_center, j_min, j_center - one_value), color)
+    draw_unchecked!(image, VerticalLine(i_min, i_center - one_value, j_center), color)
+    draw_unchecked!(image, VerticalLine(i_center + one_value, i_max, j_center), color)
+    draw_unchecked!(image, HorizontalLine(i_center, j_center + one_value, j_max), color)
 
     return nothing
 end

--- a/src/line.jl
+++ b/src/line.jl
@@ -34,19 +34,19 @@ function draw!(image::AbstractMatrix, shape::VerticalLine, color)
 
     if i_max < i_min_image || i_min > i_max_image || j < j_min_image || j > j_max_image
         return nothing
-    else
-        if i_min < i_min_image
-            i_min = i_min_image
-        end
-
-        if i_max > i_max_image
-            i_max = i_max_image
-        end
-
-        draw_unchecked!(image, VerticalLine(i_min, i_max, j), color)
-
-        return nothing
     end
+
+    if i_min < i_min_image
+        i_min = i_min_image
+    end
+
+    if i_max > i_max_image
+        i_max = i_max_image
+    end
+
+    draw_unchecked!(image, VerticalLine(i_min, i_max, j), color)
+
+    return nothing
 end
 
 @inline function draw_unchecked!(image::AbstractMatrix, shape::VerticalLine, color)
@@ -67,19 +67,19 @@ function draw!(image::AbstractMatrix, shape::HorizontalLine, color)
 
     if i < i_min_image || i > i_max_image || j_max < j_min_image || j_min > j_max_image
         return nothing
-    else
-        if j_min < j_min_image
-            j_min = j_min_image
-        end
-
-        if j_max > j_max_image
-            j_max = j_max_image
-        end
-
-        draw_unchecked!(image, HorizontalLine(i, j_min, j_max), color)
-
-        return nothing
     end
+
+    if j_min < j_min_image
+        j_min = j_min_image
+    end
+
+    if j_max > j_max_image
+        j_max = j_max_image
+    end
+
+    draw_unchecked!(image, HorizontalLine(i, j_min, j_max), color)
+
+    return nothing
 end
 
 @inline function draw_unchecked!(image::AbstractMatrix, shape::HorizontalLine, color)
@@ -90,19 +90,23 @@ end
 """
 Draw a line. Ref: https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm
 """
-function draw!(image::AbstractMatrix, shape::Line, color)
+function draw!(image::AbstractMatrix, shape::Line{I}, color) where {I}
     i1 = shape.point1.i
     j1 = shape.point1.j
     i2 = shape.point2.i
     j2 = shape.point2.j
 
+    one_value = one(I)
+
+    if j1 == j2
+        i1, i2 = minmax(i1, i2)
+        draw!(image, VerticalLine(i1, i2, j1), color)
+        return nothing
+    end
+
     if i1 == i2
         j1, j2 = minmax(j1, j2)
         draw!(image, HorizontalLine(i1, j1, j2), color)
-        return nothing
-    elseif j1 == j2
-        i1, i2 = minmax(i1, i2)
-        draw!(image, VerticalLine(i1, i2, j1), color)
         return nothing
     end
 
@@ -113,8 +117,8 @@ function draw!(image::AbstractMatrix, shape::Line, color)
 
     di = abs(i2 - i1)
     dj = -abs(j2 - j1)
-    si = i1 < i2 ? 1 : -1
-    sj = j1 < j2 ? 1 : -1
+    si = i1 < i2 ? one_value : -one_value
+    sj = j1 < j2 ? one_value : -one_value
     err = di + dj
 
     while true
@@ -124,7 +128,7 @@ function draw!(image::AbstractMatrix, shape::Line, color)
             break
         end
 
-        e2 = 2 * err
+        e2 = convert(I, 2) * err
 
         if (e2 >= dj)
             err += dj
@@ -140,16 +144,18 @@ function draw!(image::AbstractMatrix, shape::Line, color)
     return nothing
 end
 
-function draw_unchecked!(image::AbstractMatrix, shape::Line, color)
+function draw_unchecked!(image::AbstractMatrix, shape::Line{I}, color) where {I}
     i1 = shape.point1.i
     j1 = shape.point1.j
     i2 = shape.point2.i
     j2 = shape.point2.j
 
+    one_value = one(I)
+
     di = abs(i2 - i1)
     dj = -abs(j2 - j1)
-    si = i1 < i2 ? 1 : -1
-    sj = j1 < j2 ? 1 : -1
+    si = i1 < i2 ? one_value : -one_value
+    sj = j1 < j2 ? one_value : -one_value
     err = di + dj
 
     while true
@@ -159,7 +165,7 @@ function draw_unchecked!(image::AbstractMatrix, shape::Line, color)
             break
         end
 
-        e2 = 2 * err
+        e2 = convert(I, 2) * err
 
         if (e2 >= dj)
             err += dj
@@ -175,12 +181,14 @@ function draw_unchecked!(image::AbstractMatrix, shape::Line, color)
     return nothing
 end
 
-function draw!(image::AbstractMatrix, shape::ThickLine, color)
+function draw!(image::AbstractMatrix, shape::ThickLine{I}, color) where {I}
     i1 = shape.point1.i
     j1 = shape.point1.j
     i2 = shape.point2.i
     j2 = shape.point2.j
     radius = shape.radius
+
+    one_value = one(I)
 
     if checkbounds(Bool, image, i1 - radius, j1 - radius) && checkbounds(Bool, image, i1 + radius, j1 + radius) && checkbounds(Bool, image, i2 - radius, j2 - radius) && checkbounds(Bool, image, i2 + radius, j2 + radius)
         draw_unchecked!(image, shape, color)
@@ -189,8 +197,8 @@ function draw!(image::AbstractMatrix, shape::ThickLine, color)
 
     di = abs(i2 - i1)
     dj = -abs(j2 - j1)
-    si = i1 < i2 ? 1 : -1
-    sj = j1 < j2 ? 1 : -1
+    si = i1 < i2 ? one_value : -one_value
+    sj = j1 < j2 ? one_value : -one_value
     err = di + dj
 
     while true
@@ -200,7 +208,7 @@ function draw!(image::AbstractMatrix, shape::ThickLine, color)
             break
         end
 
-        e2 = 2 * err
+        e2 = convert(I, 2) * err
 
         if (e2 >= dj)
             err += dj
@@ -216,17 +224,19 @@ function draw!(image::AbstractMatrix, shape::ThickLine, color)
     return nothing
 end
 
-function draw_unchecked!(image::AbstractMatrix, shape::ThickLine, color)
+function draw_unchecked!(image::AbstractMatrix, shape::ThickLine{I}, color) where {I}
     i1 = shape.point1.i
     j1 = shape.point1.j
     i2 = shape.point2.i
     j2 = shape.point2.j
     radius = shape.radius
 
+    one_value = one(I)
+
     di = abs(i2 - i1)
     dj = -abs(j2 - j1)
-    si = i1 < i2 ? 1 : -1
-    sj = j1 < j2 ? 1 : -1
+    si = i1 < i2 ? one_value : -one_value
+    sj = j1 < j2 ? one_value : -one_value
     err = di + dj
 
     while true
@@ -236,7 +246,7 @@ function draw_unchecked!(image::AbstractMatrix, shape::ThickLine, color)
             break
         end
 
-        e2 = 2 * err
+        e2 = convert(I, 2) * err
 
         if (e2 >= dj)
             err += dj

--- a/src/line.jl
+++ b/src/line.jl
@@ -43,13 +43,13 @@ function draw!(image::AbstractMatrix, shape::VerticalLine, color)
             i_end = i_high
         end
 
-        draw_inbounds!(image, VerticalLine(i_start, i_end, j), color)
+        draw_unchecked!(image, VerticalLine(i_start, i_end, j), color)
 
         return nothing
     end
 end
 
-@inline function draw_inbounds!(image::AbstractMatrix, shape::VerticalLine, color)
+@inline function draw_unchecked!(image::AbstractMatrix, shape::VerticalLine, color)
     @inbounds image[shape.i_start:shape.i_end, shape.j] .= color
     return nothing
 end
@@ -76,13 +76,13 @@ function draw!(image::AbstractMatrix, shape::HorizontalLine, color)
             j_end = j_high
         end
 
-        draw_inbounds!(image, HorizontalLine(i, j_start, j_end), color)
+        draw_unchecked!(image, HorizontalLine(i, j_start, j_end), color)
 
         return nothing
     end
 end
 
-@inline function draw_inbounds!(image::AbstractMatrix, shape::HorizontalLine, color)
+@inline function draw_unchecked!(image::AbstractMatrix, shape::HorizontalLine, color)
     @inbounds image[shape.i, shape.j_start:shape.j_end] .= color
     return nothing
 end
@@ -107,7 +107,7 @@ function draw!(image::AbstractMatrix, shape::Line, color)
     end
 
     if checkbounds(Bool, image, i1, j1) && checkbounds(Bool, image, i2, j2)
-        draw_inbounds!(image, shape, color)
+        draw_unchecked!(image, shape, color)
         return nothing
     end
 
@@ -140,7 +140,7 @@ function draw!(image::AbstractMatrix, shape::Line, color)
     return nothing
 end
 
-function draw_inbounds!(image::AbstractMatrix, shape::Line, color)
+function draw_unchecked!(image::AbstractMatrix, shape::Line, color)
     i1 = shape.point1.i
     j1 = shape.point1.j
     i2 = shape.point2.i
@@ -183,7 +183,7 @@ function draw!(image::AbstractMatrix, shape::ThickLine, color)
     radius = shape.radius
 
     if checkbounds(Bool, image, i1 - radius, j1 - radius) && checkbounds(Bool, image, i1 + radius, j1 + radius) && checkbounds(Bool, image, i2 - radius, j2 - radius) && checkbounds(Bool, image, i2 + radius, j2 + radius)
-        draw_inbounds!(image, shape, color)
+        draw_unchecked!(image, shape, color)
         return nothing
     end
 
@@ -216,7 +216,7 @@ function draw!(image::AbstractMatrix, shape::ThickLine, color)
     return nothing
 end
 
-function draw_inbounds!(image::AbstractMatrix, shape::ThickLine, color)
+function draw_unchecked!(image::AbstractMatrix, shape::ThickLine, color)
     i1 = shape.point1.i
     j1 = shape.point1.j
     i2 = shape.point2.i
@@ -230,7 +230,7 @@ function draw_inbounds!(image::AbstractMatrix, shape::ThickLine, color)
     err = di + dj
 
     while true
-        draw_inbounds!(image, FilledCircle(Point(i1, j1), radius), color)
+        draw_unchecked!(image, FilledCircle(Point(i1, j1), radius), color)
 
         if (i1 == i2 && j1 == j2)
             break

--- a/src/line.jl
+++ b/src/line.jl
@@ -1,13 +1,13 @@
 struct VerticalLine{I <: Integer} <: AbstractShape
-    i_start::I
-    i_end::I
+    i_min::I
+    i_max::I
     j::I
 end
 
 struct HorizontalLine{I <: Integer} <: AbstractShape
     i::I
-    j_start::I
-    j_end::I
+    j_min::I
+    j_max::I
 end
 
 struct Line{I <: Integer} <: AbstractShape
@@ -22,8 +22,8 @@ struct ThickLine{I <: Integer} <: AbstractShape
 end
 
 function draw!(image::AbstractMatrix, shape::VerticalLine, color)
-    i_start = shape.i_start
-    i_end = shape.i_end
+    i_min = shape.i_min
+    i_max = shape.i_max
     j = shape.j
 
     i_low = firstindex(image, 1)
@@ -32,32 +32,32 @@ function draw!(image::AbstractMatrix, shape::VerticalLine, color)
     j_low = firstindex(image, 2)
     j_high = lastindex(image, 2)
 
-    if i_end < i_low || i_start > i_high || j < j_low || j > j_high
+    if i_max < i_low || i_min > i_high || j < j_low || j > j_high
         return nothing
     else
-        if i_start < i_low
-            i_start = i_low
+        if i_min < i_low
+            i_min = i_low
         end
 
-        if i_end > i_high
-            i_end = i_high
+        if i_max > i_high
+            i_max = i_high
         end
 
-        draw_unchecked!(image, VerticalLine(i_start, i_end, j), color)
+        draw_unchecked!(image, VerticalLine(i_min, i_max, j), color)
 
         return nothing
     end
 end
 
 @inline function draw_unchecked!(image::AbstractMatrix, shape::VerticalLine, color)
-    @inbounds image[shape.i_start:shape.i_end, shape.j] .= color
+    @inbounds image[shape.i_min:shape.i_max, shape.j] .= color
     return nothing
 end
 
 function draw!(image::AbstractMatrix, shape::HorizontalLine, color)
     i = shape.i
-    j_start = shape.j_start
-    j_end = shape.j_end
+    j_min = shape.j_min
+    j_max = shape.j_max
 
     i_low = firstindex(image, 1)
     i_high = lastindex(image, 1)
@@ -65,25 +65,25 @@ function draw!(image::AbstractMatrix, shape::HorizontalLine, color)
     j_low = firstindex(image, 2)
     j_high = lastindex(image, 2)
 
-    if i < i_low || i > i_high || j_end < j_low || j_start > j_high
+    if i < i_low || i > i_high || j_max < j_low || j_min > j_high
         return nothing
     else
-        if j_start < j_low
-            j_start = j_low
+        if j_min < j_low
+            j_min = j_low
         end
 
-        if j_end > j_high
-            j_end = j_high
+        if j_max > j_high
+            j_max = j_high
         end
 
-        draw_unchecked!(image, HorizontalLine(i, j_start, j_end), color)
+        draw_unchecked!(image, HorizontalLine(i, j_min, j_max), color)
 
         return nothing
     end
 end
 
 @inline function draw_unchecked!(image::AbstractMatrix, shape::HorizontalLine, color)
-    @inbounds image[shape.i, shape.j_start:shape.j_end] .= color
+    @inbounds image[shape.i, shape.j_min:shape.j_max] .= color
     return nothing
 end
 
@@ -252,9 +252,9 @@ function draw_unchecked!(image::AbstractMatrix, shape::ThickLine, color)
     return nothing
 end
 
-get_bounding_box(shape::VerticalLine{I}) where {I} = Rectangle(Point(shape.i_start, shape.j), shape.i_end - shape.i_start + one(I), one(I))
+get_bounding_box(shape::VerticalLine{I}) where {I} = Rectangle(Point(shape.i_min, shape.j), shape.i_max - shape.i_min + one(I), one(I))
 
-get_bounding_box(shape::HorizontalLine{I}) where {I} = Rectangle(Point(shape.i, shape.j_start), one(I), shape.j_end - shape.j_start + one(I))
+get_bounding_box(shape::HorizontalLine{I}) where {I} = Rectangle(Point(shape.i, shape.j_min), one(I), shape.j_max - shape.j_min + one(I))
 
 function get_bounding_box(shape::Line{I}) where {I}
     point1 = shape.point1

--- a/src/line.jl
+++ b/src/line.jl
@@ -153,7 +153,7 @@ function draw_inbounds!(image::AbstractMatrix, shape::Line, color)
     err = di + dj
 
     while true
-        put_pixel_inbounds!(image, i1, j1, color)
+        put_pixel_unchecked!(image, i1, j1, color)
 
         if (i1 == i2 && j1 == j2)
             break

--- a/src/line.jl
+++ b/src/line.jl
@@ -26,21 +26,21 @@ function draw!(image::AbstractMatrix, shape::VerticalLine, color)
     i_max = shape.i_max
     j = shape.j
 
-    i_low = firstindex(image, 1)
-    i_high = lastindex(image, 1)
+    i_min_image = firstindex(image, 1)
+    i_max_image = lastindex(image, 1)
 
-    j_low = firstindex(image, 2)
-    j_high = lastindex(image, 2)
+    j_min_image = firstindex(image, 2)
+    j_max_image = lastindex(image, 2)
 
-    if i_max < i_low || i_min > i_high || j < j_low || j > j_high
+    if i_max < i_min_image || i_min > i_max_image || j < j_min_image || j > j_max_image
         return nothing
     else
-        if i_min < i_low
-            i_min = i_low
+        if i_min < i_min_image
+            i_min = i_min_image
         end
 
-        if i_max > i_high
-            i_max = i_high
+        if i_max > i_max_image
+            i_max = i_max_image
         end
 
         draw_unchecked!(image, VerticalLine(i_min, i_max, j), color)
@@ -59,21 +59,21 @@ function draw!(image::AbstractMatrix, shape::HorizontalLine, color)
     j_min = shape.j_min
     j_max = shape.j_max
 
-    i_low = firstindex(image, 1)
-    i_high = lastindex(image, 1)
+    i_min_image = firstindex(image, 1)
+    i_max_image = lastindex(image, 1)
 
-    j_low = firstindex(image, 2)
-    j_high = lastindex(image, 2)
+    j_min_image = firstindex(image, 2)
+    j_max_image = lastindex(image, 2)
 
-    if i < i_low || i > i_high || j_max < j_low || j_min > j_high
+    if i < i_min_image || i > i_max_image || j_max < j_min_image || j_min > j_max_image
         return nothing
     else
-        if j_min < j_low
-            j_min = j_low
+        if j_min < j_min_image
+            j_min = j_min_image
         end
 
-        if j_max > j_high
-            j_max = j_high
+        if j_max > j_max_image
+            j_max = j_max_image
         end
 
         draw_unchecked!(image, HorizontalLine(i, j_min, j_max), color)

--- a/src/point.jl
+++ b/src/point.jl
@@ -9,7 +9,7 @@ end
 end
 
 @inline function draw_inbounds!(image::AbstractMatrix, shape::Point, color)
-    put_pixel_inbounds!(image, shape.i, shape.j, color)
+    put_pixel_unchecked!(image, shape.i, shape.j, color)
     return nothing
 end
 

--- a/src/point.jl
+++ b/src/point.jl
@@ -8,7 +8,7 @@ end
     return nothing
 end
 
-@inline function draw_inbounds!(image::AbstractMatrix, shape::Point, color)
+@inline function draw_unchecked!(image::AbstractMatrix, shape::Point, color)
     put_pixel_unchecked!(image, shape.i, shape.j, color)
     return nothing
 end

--- a/src/polyline.jl
+++ b/src/polyline.jl
@@ -20,18 +20,18 @@ function draw!(image::AbstractMatrix, shape::Polyline, color)
     end
 end
 
-function draw_inbounds!(image::AbstractMatrix, shape::Polyline, color)
+function draw_unchecked!(image::AbstractMatrix, shape::Polyline, color)
     points = shape.points
     num_points = length(points)
 
     if num_points == 0
         return nothing
     elseif num_points == 1
-        draw_inbounds!(image, first(points), color)
+        draw_unchecked!(image, first(points), color)
         return nothing
     else
         for i in 1 : num_points - 1
-            draw_inbounds!(image, Line(points[i], points[i + 1]), color)
+            draw_unchecked!(image, Line(points[i], points[i + 1]), color)
         end
 
         return nothing

--- a/src/polyline.jl
+++ b/src/polyline.jl
@@ -2,40 +2,38 @@ struct Polyline{I <: Integer} <: AbstractShape
     points::Vector{Point{I}}
 end
 
-function draw!(image::AbstractMatrix, shape::Polyline, color)
+function draw!(image::AbstractMatrix, shape::Polyline{I}, color) where {I}
     points = shape.points
     num_points = length(points)
 
-    if num_points == 0
-        return nothing
-    elseif num_points == 1
-        draw!(image, first(points), color)
-        return nothing
-    else
-        for i in 1 : num_points - 1
-            draw!(image, Line(points[i], points[i + 1]), color)
-        end
+    zero_value = zero(I)
+    one_value = one(I)
 
+    if num_points == zero_value
         return nothing
     end
+
+    if num_points == one_value
+        draw!(image, first(points), color)
+        return nothing
+    end
+
+    for i in 1 : num_points - 1
+        draw!(image, Line(points[i], points[i + 1]), color)
+    end
+
+    return nothing
 end
 
 function draw_unchecked!(image::AbstractMatrix, shape::Polyline, color)
     points = shape.points
     num_points = length(points)
 
-    if num_points == 0
-        return nothing
-    elseif num_points == 1
-        draw_unchecked!(image, first(points), color)
-        return nothing
-    else
-        for i in 1 : num_points - 1
-            draw_unchecked!(image, Line(points[i], points[i + 1]), color)
-        end
-
-        return nothing
+    for i in 1 : num_points - 1
+        draw_unchecked!(image, Line(points[i], points[i + 1]), color)
     end
+
+    return nothing
 end
 
 function get_bounding_box(shape::Polyline{I}) where {I}

--- a/src/rectangle.jl
+++ b/src/rectangle.jl
@@ -24,7 +24,7 @@ function draw!(image::AbstractMatrix, shape::Rectangle, color)
     j_bottom_right = j_top_left + shape.width - 1
 
     if checkbounds(Bool, image, i_top_left, j_top_left) && checkbounds(Bool, image, i_bottom_right, j_bottom_right)
-        draw_inbounds!(image, shape, color)
+        draw_unchecked!(image, shape, color)
         return nothing
     end
 
@@ -36,16 +36,16 @@ function draw!(image::AbstractMatrix, shape::Rectangle, color)
     return nothing
 end
 
-function draw_inbounds!(image::AbstractMatrix, shape::Rectangle, color)
+function draw_unchecked!(image::AbstractMatrix, shape::Rectangle, color)
     i_top_left = shape.top_left.i
     j_top_left = shape.top_left.j
     i_bottom_right = i_top_left + shape.height - 1
     j_bottom_right = j_top_left + shape.width - 1
 
-    draw_inbounds!(image, VerticalLine(i_top_left, i_bottom_right, j_top_left), color)
-    draw_inbounds!(image, HorizontalLine(i_top_left, j_top_left, j_bottom_right), color)
-    draw_inbounds!(image, HorizontalLine(i_bottom_right, j_top_left, j_bottom_right), color)
-    draw_inbounds!(image, VerticalLine(i_top_left, i_bottom_right, j_bottom_right), color)
+    draw_unchecked!(image, VerticalLine(i_top_left, i_bottom_right, j_top_left), color)
+    draw_unchecked!(image, HorizontalLine(i_top_left, j_top_left, j_bottom_right), color)
+    draw_unchecked!(image, HorizontalLine(i_bottom_right, j_top_left, j_bottom_right), color)
+    draw_unchecked!(image, VerticalLine(i_top_left, i_bottom_right, j_bottom_right), color)
 
     return nothing
 end
@@ -62,7 +62,7 @@ function draw!(image::AbstractMatrix, shape::ThickRectangle, color)
     j_bottom_right = j_top_left + width - 1
 
     if checkbounds(Bool, image, i_top_left, j_top_left) && checkbounds(Bool, image, i_bottom_right, j_bottom_right)
-        draw_inbounds!(image, shape, color)
+        draw_unchecked!(image, shape, color)
         return nothing
     end
 
@@ -74,7 +74,7 @@ function draw!(image::AbstractMatrix, shape::ThickRectangle, color)
     return nothing
 end
 
-function draw_inbounds!(image::AbstractMatrix, shape::ThickRectangle, color)
+function draw_unchecked!(image::AbstractMatrix, shape::ThickRectangle, color)
     top_left = shape.top_left
     height = shape.height
     width = shape.width
@@ -84,10 +84,10 @@ function draw_inbounds!(image::AbstractMatrix, shape::ThickRectangle, color)
     i_bottom_right = i_top_left + height - 1
     j_bottom_right = j_top_left + width - 1
 
-    draw_inbounds!(image, FilledRectangle(top_left, height, thickness), color)
-    draw_inbounds!(image, FilledRectangle(Point(i_top_left, j_top_left + thickness), thickness, width - 2 * thickness), color)
-    draw_inbounds!(image, FilledRectangle(Point(i_top_left + height - thickness, j_top_left + thickness), thickness, width - 2 * thickness), color)
-    draw_inbounds!(image, FilledRectangle(Point(i_top_left, j_top_left + width - thickness), height, thickness), color)
+    draw_unchecked!(image, FilledRectangle(top_left, height, thickness), color)
+    draw_unchecked!(image, FilledRectangle(Point(i_top_left, j_top_left + thickness), thickness, width - 2 * thickness), color)
+    draw_unchecked!(image, FilledRectangle(Point(i_top_left + height - thickness, j_top_left + thickness), thickness, width - 2 * thickness), color)
+    draw_unchecked!(image, FilledRectangle(Point(i_top_left, j_top_left + width - thickness), height, thickness), color)
 
     return nothing
 end
@@ -133,7 +133,7 @@ function draw!(image::AbstractMatrix, shape::FilledRectangle, color)
     return nothing
 end
 
-function draw_inbounds!(image::AbstractMatrix, shape::FilledRectangle, color)
+function draw_unchecked!(image::AbstractMatrix, shape::FilledRectangle, color)
     i_top_left = shape.top_left.i
     j_top_left = shape.top_left.j
     i_bottom_right = i_top_left + shape.height - 1

--- a/src/rectangle.jl
+++ b/src/rectangle.jl
@@ -1,102 +1,102 @@
 struct Rectangle{I <: Integer} <: AbstractShape
-    top_left::Point{I}
+    origin::Point{I}
     height::I
     width::I
 end
 
 struct ThickRectangle{I <: Integer} <: AbstractShape
-    top_left::Point{I}
+    origin::Point{I}
     height::I
     width::I
     thickness::I
 end
 
 struct FilledRectangle{I <: Integer} <: AbstractShape
-    top_left::Point{I}
+    origin::Point{I}
     height::I
     width::I
 end
 
 function draw!(image::AbstractMatrix, shape::Rectangle, color)
-    i_top_left = shape.top_left.i
-    j_top_left = shape.top_left.j
-    i_bottom_right = i_top_left + shape.height - 1
-    j_bottom_right = j_top_left + shape.width - 1
+    i_min = shape.origin.i
+    j_min = shape.origin.j
+    i_max = i_min + shape.height - 1
+    j_max = j_min + shape.width - 1
 
-    if checkbounds(Bool, image, i_top_left, j_top_left) && checkbounds(Bool, image, i_bottom_right, j_bottom_right)
+    if checkbounds(Bool, image, i_min, j_min) && checkbounds(Bool, image, i_max, j_max)
         draw_unchecked!(image, shape, color)
         return nothing
     end
 
-    draw!(image, VerticalLine(i_top_left, i_bottom_right, j_top_left), color)
-    draw!(image, HorizontalLine(i_top_left, j_top_left, j_bottom_right), color)
-    draw!(image, HorizontalLine(i_bottom_right, j_top_left, j_bottom_right), color)
-    draw!(image, VerticalLine(i_top_left, i_bottom_right, j_bottom_right), color)
+    draw!(image, VerticalLine(i_min, i_max, j_min), color)
+    draw!(image, HorizontalLine(i_min, j_min, j_max), color)
+    draw!(image, HorizontalLine(i_max, j_min, j_max), color)
+    draw!(image, VerticalLine(i_min, i_max, j_max), color)
 
     return nothing
 end
 
 function draw_unchecked!(image::AbstractMatrix, shape::Rectangle, color)
-    i_top_left = shape.top_left.i
-    j_top_left = shape.top_left.j
-    i_bottom_right = i_top_left + shape.height - 1
-    j_bottom_right = j_top_left + shape.width - 1
+    i_min = shape.origin.i
+    j_min = shape.origin.j
+    i_max = i_min + shape.height - 1
+    j_max = j_min + shape.width - 1
 
-    draw_unchecked!(image, VerticalLine(i_top_left, i_bottom_right, j_top_left), color)
-    draw_unchecked!(image, HorizontalLine(i_top_left, j_top_left, j_bottom_right), color)
-    draw_unchecked!(image, HorizontalLine(i_bottom_right, j_top_left, j_bottom_right), color)
-    draw_unchecked!(image, VerticalLine(i_top_left, i_bottom_right, j_bottom_right), color)
+    draw_unchecked!(image, VerticalLine(i_min, i_max, j_min), color)
+    draw_unchecked!(image, HorizontalLine(i_min, j_min, j_max), color)
+    draw_unchecked!(image, HorizontalLine(i_max, j_min, j_max), color)
+    draw_unchecked!(image, VerticalLine(i_min, i_max, j_max), color)
 
     return nothing
 end
 
 function draw!(image::AbstractMatrix, shape::ThickRectangle, color)
-    top_left = shape.top_left
+    origin = shape.origin
     height = shape.height
     width = shape.width
     thickness = shape.thickness
 
-    i_top_left = top_left.i
-    j_top_left = top_left.j
-    i_bottom_right = i_top_left + height - 1
-    j_bottom_right = j_top_left + width - 1
+    i_min = origin.i
+    j_min = origin.j
+    i_max = i_min + height - 1
+    j_max = j_min + width - 1
 
-    if checkbounds(Bool, image, i_top_left, j_top_left) && checkbounds(Bool, image, i_bottom_right, j_bottom_right)
+    if checkbounds(Bool, image, i_min, j_min) && checkbounds(Bool, image, i_max, j_max)
         draw_unchecked!(image, shape, color)
         return nothing
     end
 
-    draw!(image, FilledRectangle(top_left, height, thickness), color)
-    draw!(image, FilledRectangle(Point(i_top_left, j_top_left + thickness), thickness, width - 2 * thickness), color)
-    draw!(image, FilledRectangle(Point(i_top_left + height - thickness, j_top_left + thickness), thickness, width - 2 * thickness), color)
-    draw!(image, FilledRectangle(Point(i_top_left, j_top_left + width - thickness), height, thickness), color)
+    draw!(image, FilledRectangle(origin, height, thickness), color)
+    draw!(image, FilledRectangle(Point(i_min, j_min + thickness), thickness, width - 2 * thickness), color)
+    draw!(image, FilledRectangle(Point(i_min + height - thickness, j_min + thickness), thickness, width - 2 * thickness), color)
+    draw!(image, FilledRectangle(Point(i_min, j_min + width - thickness), height, thickness), color)
 
     return nothing
 end
 
 function draw_unchecked!(image::AbstractMatrix, shape::ThickRectangle, color)
-    top_left = shape.top_left
+    origin = shape.origin
     height = shape.height
     width = shape.width
     thickness = shape.thickness
-    i_top_left = top_left.i
-    j_top_left = top_left.j
-    i_bottom_right = i_top_left + height - 1
-    j_bottom_right = j_top_left + width - 1
+    i_min = origin.i
+    j_min = origin.j
+    i_max = i_min + height - 1
+    j_max = j_min + width - 1
 
-    draw_unchecked!(image, FilledRectangle(top_left, height, thickness), color)
-    draw_unchecked!(image, FilledRectangle(Point(i_top_left, j_top_left + thickness), thickness, width - 2 * thickness), color)
-    draw_unchecked!(image, FilledRectangle(Point(i_top_left + height - thickness, j_top_left + thickness), thickness, width - 2 * thickness), color)
-    draw_unchecked!(image, FilledRectangle(Point(i_top_left, j_top_left + width - thickness), height, thickness), color)
+    draw_unchecked!(image, FilledRectangle(origin, height, thickness), color)
+    draw_unchecked!(image, FilledRectangle(Point(i_min, j_min + thickness), thickness, width - 2 * thickness), color)
+    draw_unchecked!(image, FilledRectangle(Point(i_min + height - thickness, j_min + thickness), thickness, width - 2 * thickness), color)
+    draw_unchecked!(image, FilledRectangle(Point(i_min, j_min + width - thickness), height, thickness), color)
 
     return nothing
 end
 
 function draw!(image::AbstractMatrix, shape::FilledRectangle, color)
-    i_top_left = shape.top_left.i
-    j_top_left = shape.top_left.j
-    i_bottom_right = i_top_left + shape.height - 1
-    j_bottom_right = j_top_left + shape.width - 1
+    i_min = shape.origin.i
+    j_min = shape.origin.j
+    i_max = i_min + shape.height - 1
+    j_max = j_min + shape.width - 1
 
     i_min_image = firstindex(image, 1)
     i_max_image = lastindex(image, 1)
@@ -104,46 +104,46 @@ function draw!(image::AbstractMatrix, shape::FilledRectangle, color)
     j_min_image = firstindex(image, 2)
     j_max_image = lastindex(image, 2)
 
-    if i_top_left > i_max_image
+    if i_min > i_max_image
         return nothing
-    elseif i_top_left < i_min_image
-        i_top_left = i_min_image
+    elseif i_min < i_min_image
+        i_min = i_min_image
     end
 
-    if i_bottom_right < i_min_image
+    if i_max < i_min_image
         return nothing
-    elseif i_bottom_right > i_max_image
-        i_bottom_right = i_max_image
+    elseif i_max > i_max_image
+        i_max = i_max_image
     end
 
-    if j_top_left > j_max_image
+    if j_min > j_max_image
         return nothing
-    elseif j_top_left < j_min_image
-        j_top_left = j_min_image
+    elseif j_min < j_min_image
+        j_min = j_min_image
     end
 
-    if j_bottom_right < j_min_image
+    if j_max < j_min_image
         return nothing
-    elseif j_bottom_right > j_max_image
-        j_bottom_right = j_max_image
+    elseif j_max > j_max_image
+        j_max = j_max_image
     end
 
-    @inbounds image[i_top_left:i_bottom_right, j_top_left:j_bottom_right] .= color
+    @inbounds image[i_min:i_max, j_min:j_max] .= color
 
     return nothing
 end
 
 function draw_unchecked!(image::AbstractMatrix, shape::FilledRectangle, color)
-    i_top_left = shape.top_left.i
-    j_top_left = shape.top_left.j
-    i_bottom_right = i_top_left + shape.height - 1
-    j_bottom_right = j_top_left + shape.width - 1
+    i_min = shape.origin.i
+    j_min = shape.origin.j
+    i_max = i_min + shape.height - 1
+    j_max = j_min + shape.width - 1
 
-    @inbounds image[i_top_left:i_bottom_right, j_top_left:j_bottom_right] .= color
+    @inbounds image[i_min:i_max, j_min:j_max] .= color
 
     return nothing
 end
 
 get_bounding_box(shape::Rectangle) = shape
-get_bounding_box(shape::ThickRectangle) = Rectangle(shape.top_left, shape.height, shape.width)
-get_bounding_box(shape::FilledRectangle) = Rectangle(shape.top_left, shape.height, shape.width)
+get_bounding_box(shape::ThickRectangle) = Rectangle(shape.origin, shape.height, shape.width)
+get_bounding_box(shape::FilledRectangle) = Rectangle(shape.origin, shape.height, shape.width)

--- a/src/rectangle.jl
+++ b/src/rectangle.jl
@@ -17,86 +17,22 @@ struct FilledRectangle{I <: Integer} <: AbstractShape
     width::I
 end
 
-function draw!(image::AbstractMatrix, shape::Rectangle, color)
-    i_min = shape.origin.i
-    j_min = shape.origin.j
-    i_max = i_min + shape.height - 1
-    j_max = j_min + shape.width - 1
-
-    if checkbounds(Bool, image, i_min, j_min) && checkbounds(Bool, image, i_max, j_max)
-        draw_unchecked!(image, shape, color)
-        return nothing
-    end
-
-    draw!(image, VerticalLine(i_min, i_max, j_min), color)
-    draw!(image, HorizontalLine(i_min, j_min, j_max), color)
-    draw!(image, HorizontalLine(i_max, j_min, j_max), color)
-    draw!(image, VerticalLine(i_min, i_max, j_max), color)
-
-    return nothing
-end
-
-function draw_unchecked!(image::AbstractMatrix, shape::Rectangle, color)
-    i_min = shape.origin.i
-    j_min = shape.origin.j
-    i_max = i_min + shape.height - 1
-    j_max = j_min + shape.width - 1
-
-    draw_unchecked!(image, VerticalLine(i_min, i_max, j_min), color)
-    draw_unchecked!(image, HorizontalLine(i_min, j_min, j_max), color)
-    draw_unchecked!(image, HorizontalLine(i_max, j_min, j_max), color)
-    draw_unchecked!(image, VerticalLine(i_min, i_max, j_max), color)
-
-    return nothing
-end
-
-function draw!(image::AbstractMatrix, shape::ThickRectangle, color)
+function draw!(image::AbstractMatrix, shape::Rectangle{I}, color) where {I}
     origin = shape.origin
     height = shape.height
     width = shape.width
-    thickness = shape.thickness
 
-    i_min = origin.i
-    j_min = origin.j
-    i_max = i_min + height - 1
-    j_max = j_min + width - 1
+    one_value = one(I)
 
-    if checkbounds(Bool, image, i_min, j_min) && checkbounds(Bool, image, i_max, j_max)
-        draw_unchecked!(image, shape, color)
+    if height < one_value || width < one_value
         return nothing
     end
 
-    draw!(image, FilledRectangle(origin, height, thickness), color)
-    draw!(image, FilledRectangle(Point(i_min, j_min + thickness), thickness, width - 2 * thickness), color)
-    draw!(image, FilledRectangle(Point(i_min + height - thickness, j_min + thickness), thickness, width - 2 * thickness), color)
-    draw!(image, FilledRectangle(Point(i_min, j_min + width - thickness), height, thickness), color)
-
-    return nothing
-end
-
-function draw_unchecked!(image::AbstractMatrix, shape::ThickRectangle, color)
-    origin = shape.origin
-    height = shape.height
-    width = shape.width
-    thickness = shape.thickness
     i_min = origin.i
     j_min = origin.j
-    i_max = i_min + height - 1
-    j_max = j_min + width - 1
 
-    draw_unchecked!(image, FilledRectangle(origin, height, thickness), color)
-    draw_unchecked!(image, FilledRectangle(Point(i_min, j_min + thickness), thickness, width - 2 * thickness), color)
-    draw_unchecked!(image, FilledRectangle(Point(i_min + height - thickness, j_min + thickness), thickness, width - 2 * thickness), color)
-    draw_unchecked!(image, FilledRectangle(Point(i_min, j_min + width - thickness), height, thickness), color)
-
-    return nothing
-end
-
-function draw!(image::AbstractMatrix, shape::FilledRectangle, color)
-    i_min = shape.origin.i
-    j_min = shape.origin.j
-    i_max = i_min + shape.height - 1
-    j_max = j_min + shape.width - 1
+    i_max = i_min + height - one_value
+    j_max = j_min + width - one_value
 
     i_min_image = firstindex(image, 1)
     i_max_image = lastindex(image, 1)
@@ -104,27 +40,159 @@ function draw!(image::AbstractMatrix, shape::FilledRectangle, color)
     j_min_image = firstindex(image, 2)
     j_max_image = lastindex(image, 2)
 
-    if i_min > i_max_image
+    if i_max < i_min_image || i_min > i_max_image || j_max < j_min_image || j_min > j_max_image
         return nothing
-    elseif i_min < i_min_image
+    end
+
+    if i_min >= i_min_image && j_min >= j_min_image && i_max <= i_max_image && j_max <= j_max_image
+        draw_unchecked!(image, shape, color)
+        return nothing
+    end
+
+    j_min_plus_1 = j_min + one_value
+    j_max_minus_1 = j_max - one_value
+
+    draw!(image, VerticalLine(i_min, i_max, j_min), color)
+    draw!(image, HorizontalLine(i_min, j_min_plus_1, j_max_minus_1), color)
+    draw!(image, HorizontalLine(i_max, j_min_plus_1, j_max_minus_1), color)
+    draw!(image, VerticalLine(i_min, i_max, j_max), color)
+
+    return nothing
+end
+
+function draw_unchecked!(image::AbstractMatrix, shape::Rectangle{I}, color) where {I}
+    origin = shape.origin
+    height = shape.height
+    width = shape.width
+
+    one_value = one(I)
+
+    i_min = origin.i
+    j_min = origin.j
+
+    i_max = i_min + height - one_value
+    j_max = j_min + width - one_value
+
+    j_min_plus_1 = j_min + one_value
+    j_max_minus_1 = j_max - one_value
+
+    draw_unchecked!(image, VerticalLine(i_min, i_max, j_min), color)
+    draw_unchecked!(image, HorizontalLine(i_min, j_min_plus_1, j_max_minus_1), color)
+    draw_unchecked!(image, HorizontalLine(i_max, j_min_plus_1, j_max_minus_1), color)
+    draw_unchecked!(image, VerticalLine(i_min, i_max, j_max), color)
+
+    return nothing
+end
+
+function draw!(image::AbstractMatrix, shape::ThickRectangle{I}, color) where {I}
+    origin = shape.origin
+    height = shape.height
+    width = shape.width
+    thickness = shape.thickness
+
+    one_value = one(I)
+
+    if height < one_value || width < one_value || thickness < one_value
+        return nothing
+    end
+
+    i_min = origin.i
+    j_min = origin.j
+
+    i_max = i_min + height - one_value
+    j_max = j_min + width - one_value
+
+    i_min_image = firstindex(image, 1)
+    i_max_image = lastindex(image, 1)
+
+    j_min_image = firstindex(image, 2)
+    j_max_image = lastindex(image, 2)
+
+    if i_max < i_min_image || i_min > i_max_image || j_max < j_min_image || j_min > j_max_image
+        return nothing
+    end
+
+    if i_min >= i_min_image && j_min >= j_min_image && i_max <= i_max_image && j_max <= j_max_image
+        draw_unchecked!(image, shape, color)
+        return nothing
+    end
+
+    j_min_plus_thickness = j_min + thickness
+    width_minus_twice_thickness = width - convert(I, 2) * thickness
+
+    draw!(image, FilledRectangle(origin, height, thickness), color)
+    draw!(image, FilledRectangle(Point(i_min, j_min_plus_thickness), thickness, width_minus_twice_thickness), color)
+    draw!(image, FilledRectangle(Point(i_min + height - thickness, j_min_plus_thickness), thickness, width_minus_twice_thickness), color)
+    draw!(image, FilledRectangle(Point(i_min, j_min + width - thickness), height, thickness), color)
+
+    return nothing
+end
+
+function draw_unchecked!(image::AbstractMatrix, shape::ThickRectangle{I}, color) where {I}
+    origin = shape.origin
+    height = shape.height
+    width = shape.width
+    thickness = shape.thickness
+
+    one_value = one(I)
+
+    i_min = origin.i
+    j_min = origin.j
+
+    i_max = i_min + height - one_value
+    j_max = j_min + width - one_value
+
+    j_min_plus_thickness = j_min + thickness
+    width_minus_twice_thickness = width - convert(I, 2) * thickness
+
+    draw_unchecked!(image, FilledRectangle(origin, height, thickness), color)
+    draw_unchecked!(image, FilledRectangle(Point(i_min, j_min_plus_thickness), thickness, width_minus_twice_thickness), color)
+    draw_unchecked!(image, FilledRectangle(Point(i_min + height - thickness, j_min_plus_thickness), thickness, width_minus_twice_thickness), color)
+    draw_unchecked!(image, FilledRectangle(Point(i_min, j_min + width - thickness), height, thickness), color)
+
+    return nothing
+end
+
+function draw!(image::AbstractMatrix, shape::FilledRectangle{I}, color) where {I}
+    origin = shape.origin
+    height = shape.height
+    width = shape.width
+
+    one_value = one(I)
+
+    if height < one_value || width < one_value
+        return nothing
+    end
+
+    i_min = origin.i
+    j_min = origin.j
+
+    i_max = i_min + height - one_value
+    j_max = j_min + width - one_value
+
+    i_min_image = firstindex(image, 1)
+    i_max_image = lastindex(image, 1)
+
+    j_min_image = firstindex(image, 2)
+    j_max_image = lastindex(image, 2)
+
+    if i_max < i_min_image || i_min > i_max_image || j_max < j_min_image || j_min > j_max_image
+        return nothing
+    end
+
+    if i_min < i_min_image
         i_min = i_min_image
     end
 
-    if i_max < i_min_image
-        return nothing
-    elseif i_max > i_max_image
+    if i_max > i_max_image
         i_max = i_max_image
     end
 
-    if j_min > j_max_image
-        return nothing
-    elseif j_min < j_min_image
+    if j_min < j_min_image
         j_min = j_min_image
     end
 
-    if j_max < j_min_image
-        return nothing
-    elseif j_max > j_max_image
+    if j_max > j_max_image
         j_max = j_max_image
     end
 
@@ -133,11 +201,18 @@ function draw!(image::AbstractMatrix, shape::FilledRectangle, color)
     return nothing
 end
 
-function draw_unchecked!(image::AbstractMatrix, shape::FilledRectangle, color)
-    i_min = shape.origin.i
-    j_min = shape.origin.j
-    i_max = i_min + shape.height - 1
-    j_max = j_min + shape.width - 1
+function draw_unchecked!(image::AbstractMatrix, shape::FilledRectangle{I}, color) where {I}
+    origin = shape.origin
+    height = shape.height
+    width = shape.width
+
+    one_value = one(I)
+
+    i_min = origin.i
+    j_min = origin.j
+
+    i_max = i_min + height - one_value
+    j_max = j_min + width - one_value
 
     @inbounds image[i_min:i_max, j_min:j_max] .= color
 

--- a/src/rectangle.jl
+++ b/src/rectangle.jl
@@ -98,34 +98,34 @@ function draw!(image::AbstractMatrix, shape::FilledRectangle, color)
     i_bottom_right = i_top_left + shape.height - 1
     j_bottom_right = j_top_left + shape.width - 1
 
-    i_low = firstindex(image, 1)
-    i_high = lastindex(image, 1)
+    i_min_image = firstindex(image, 1)
+    i_max_image = lastindex(image, 1)
 
-    j_low = firstindex(image, 2)
-    j_high = lastindex(image, 2)
+    j_min_image = firstindex(image, 2)
+    j_max_image = lastindex(image, 2)
 
-    if i_top_left > i_high
+    if i_top_left > i_max_image
         return nothing
-    elseif i_top_left < i_low
-        i_top_left = i_low
+    elseif i_top_left < i_min_image
+        i_top_left = i_min_image
     end
 
-    if i_bottom_right < i_low
+    if i_bottom_right < i_min_image
         return nothing
-    elseif i_bottom_right > i_high
-        i_bottom_right = i_high
+    elseif i_bottom_right > i_max_image
+        i_bottom_right = i_max_image
     end
 
-    if j_top_left > j_high
+    if j_top_left > j_max_image
         return nothing
-    elseif j_top_left < j_low
-        j_top_left = j_low
+    elseif j_top_left < j_min_image
+        j_top_left = j_min_image
     end
 
-    if j_bottom_right < j_low
+    if j_bottom_right < j_min_image
         return nothing
-    elseif j_bottom_right > j_high
-        j_bottom_right = j_high
+    elseif j_bottom_right > j_max_image
+        j_bottom_right = j_max_image
     end
 
     @inbounds image[i_top_left:i_bottom_right, j_top_left:j_bottom_right] .= color


### PR DESCRIPTION
Rename `draw_inbounds!` to `draw_unchecked!`. `draw_unchecked!` makes a bunch of assumptions, including that the shape is in bounds.
Resolve a lot of corner cases. Like `Circle` with radius `0`, rectangle with negative `height` or `width`, etc.
Rename bunch of other variables: `top_left` to `origin`, `i_start` to `i_min`, `i_end` to i_max` and similarly for `j`, etc.
Try to use generic number constants wherever possible. For example, `one(I)` and `convert(I, 2)` instead of 1 and 2 respectively.