### PR TITLE
refactor line shapes

### DIFF
--- a/src/circle.jl
+++ b/src/circle.jl
@@ -34,20 +34,20 @@ end
 end
 
 @inline function draw_vertical_strip_reflections_unchecked!(image::AbstractMatrix, i_center::Integer, j_center::Integer, i::Integer, j::Integer, color)
-    draw_unchecked!(image, VerticalLine(i_center - i, i_center + i, j_center - j), color)
-    draw_unchecked!(image, VerticalLine(i_center - j, i_center + j, j_center - i), color)
-    draw_unchecked!(image, VerticalLine(i_center - j, i_center + j, j_center + i), color)
-    draw_unchecked!(image, VerticalLine(i_center - i, i_center + i, j_center + j), color)
+    _draw!(image, VerticalLine(i_center - i, i_center + i, j_center - j), color)
+    _draw!(image, VerticalLine(i_center - j, i_center + j, j_center - i), color)
+    _draw!(image, VerticalLine(i_center - j, i_center + j, j_center + i), color)
+    _draw!(image, VerticalLine(i_center - i, i_center + i, j_center + j), color)
 
     return nothing
 end
 
 @inline function draw_vertical_strip_reflections_even_unchecked!(image::AbstractMatrix, i_center::Integer, j_center::Integer, i::Integer, j::Integer, color)
     one_value = one(i_center)
-    draw_unchecked!(image, VerticalLine(i_center - i, i_center + i - one_value, j_center - j), color)
-    draw_unchecked!(image, VerticalLine(i_center - j, i_center + j - one_value, j_center - i), color)
-    draw_unchecked!(image, VerticalLine(i_center - j, i_center + j - one_value, j_center + i - one_value), color)
-    draw_unchecked!(image, VerticalLine(i_center - i, i_center + i - one_value, j_center + j - one_value), color)
+    _draw!(image, VerticalLine(i_center - i, i_center + i - one_value, j_center - j), color)
+    _draw!(image, VerticalLine(i_center - j, i_center + j - one_value, j_center - i), color)
+    _draw!(image, VerticalLine(i_center - j, i_center + j - one_value, j_center + i - one_value), color)
+    _draw!(image, VerticalLine(i_center - i, i_center + i - one_value, j_center + j - one_value), color)
 
     return nothing
 end
@@ -120,28 +120,28 @@ end
 end
 
 @inline function draw_octant_reflections_lines_unchecked!(image::AbstractMatrix, i_center, j_center, i, j_inner, j_outer, color)
-    draw_unchecked!(image, HorizontalLine(i_center - i, j_center - j_outer, j_center - j_inner), color)
-    draw_unchecked!(image, HorizontalLine(i_center + i, j_center - j_outer, j_center - j_inner), color)
-    draw_unchecked!(image, VerticalLine(i_center - j_outer, i_center - j_inner, j_center - i), color)
-    draw_unchecked!(image, VerticalLine(i_center + j_inner, i_center + j_outer, j_center - i), color)
-    draw_unchecked!(image, VerticalLine(i_center - j_outer, i_center - j_inner, j_center + i), color)
-    draw_unchecked!(image, VerticalLine(i_center + j_inner, i_center + j_outer, j_center + i), color)
-    draw_unchecked!(image, HorizontalLine(i_center - i, j_center + j_inner, j_center + j_outer), color)
-    draw_unchecked!(image, HorizontalLine(i_center + i, j_center + j_inner, j_center + j_outer), color)
+    _draw!(image, HorizontalLine(i_center - i, j_center - j_outer, j_center - j_inner), color)
+    _draw!(image, HorizontalLine(i_center + i, j_center - j_outer, j_center - j_inner), color)
+    _draw!(image, VerticalLine(i_center - j_outer, i_center - j_inner, j_center - i), color)
+    _draw!(image, VerticalLine(i_center + j_inner, i_center + j_outer, j_center - i), color)
+    _draw!(image, VerticalLine(i_center - j_outer, i_center - j_inner, j_center + i), color)
+    _draw!(image, VerticalLine(i_center + j_inner, i_center + j_outer, j_center + i), color)
+    _draw!(image, HorizontalLine(i_center - i, j_center + j_inner, j_center + j_outer), color)
+    _draw!(image, HorizontalLine(i_center + i, j_center + j_inner, j_center + j_outer), color)
 
     return nothing
 end
 
 @inline function draw_octant_reflections_lines_even_unchecked!(image::AbstractMatrix, i_center, j_center, i, j_inner, j_outer, color)
     one_value = one(i_center)
-    draw_unchecked!(image, HorizontalLine(i_center - i, j_center - j_outer, j_center - j_inner), color)
-    draw_unchecked!(image, HorizontalLine(i_center + i - one_value, j_center - j_outer, j_center - j_inner), color)
-    draw_unchecked!(image, VerticalLine(i_center - j_outer, i_center - j_inner, j_center - i), color)
-    draw_unchecked!(image, VerticalLine(i_center + j_inner - one_value, i_center + j_outer - one_value, j_center - i), color)
-    draw_unchecked!(image, VerticalLine(i_center - j_outer, i_center - j_inner, j_center + i - one_value), color)
-    draw_unchecked!(image, VerticalLine(i_center + j_inner - one_value, i_center + j_outer - one_value, j_center + i - one_value), color)
-    draw_unchecked!(image, HorizontalLine(i_center - i, j_center + j_inner - one_value, j_center + j_outer - one_value), color)
-    draw_unchecked!(image, HorizontalLine(i_center + i - one_value, j_center + j_inner - one_value, j_center + j_outer - one_value), color)
+    _draw!(image, HorizontalLine(i_center - i, j_center - j_outer, j_center - j_inner), color)
+    _draw!(image, HorizontalLine(i_center + i - one_value, j_center - j_outer, j_center - j_inner), color)
+    _draw!(image, VerticalLine(i_center - j_outer, i_center - j_inner, j_center - i), color)
+    _draw!(image, VerticalLine(i_center + j_inner - one_value, i_center + j_outer - one_value, j_center - i), color)
+    _draw!(image, VerticalLine(i_center - j_outer, i_center - j_inner, j_center + i - one_value), color)
+    _draw!(image, VerticalLine(i_center + j_inner - one_value, i_center + j_outer - one_value, j_center + i - one_value), color)
+    _draw!(image, HorizontalLine(i_center - i, j_center + j_inner - one_value, j_center + j_outer - one_value), color)
+    _draw!(image, HorizontalLine(i_center + i - one_value, j_center + j_inner - one_value, j_center + j_outer - one_value), color)
 
     return nothing
 end

--- a/src/cross.jl
+++ b/src/cross.jl
@@ -67,8 +67,8 @@ function draw_unchecked!(image::AbstractMatrix, shape::Cross, color)
     i_center = i_position + radius
     j_center = j_position + radius
 
-    draw_unchecked!(image, HorizontalLine(i_center, j_center - radius, j_center + radius), color)
-    draw_unchecked!(image, VerticalLine(i_center - radius, i_center + radius, j_center), color)
+    _draw!(image, HorizontalLine(i_center, j_center - radius, j_center + radius), color)
+    _draw!(image, VerticalLine(i_center - radius, i_center + radius, j_center), color)
 
     return nothing
 end
@@ -138,10 +138,10 @@ function draw_unchecked!(image::AbstractMatrix, shape::HollowCross{I}, color) wh
     i_max = i_position + diameter_minus_1
     j_max = j_position + diameter_minus_1
 
-    draw_unchecked!(image, HorizontalLine(i_center, j_min, j_center - one_value), color)
-    draw_unchecked!(image, VerticalLine(i_min, i_center - one_value, j_center), color)
-    draw_unchecked!(image, VerticalLine(i_center + one_value, i_max, j_center), color)
-    draw_unchecked!(image, HorizontalLine(i_center, j_center + one_value, j_max), color)
+    _draw!(image, HorizontalLine(i_center, j_min, j_center - one_value), color)
+    _draw!(image, VerticalLine(i_min, i_center - one_value, j_center), color)
+    _draw!(image, VerticalLine(i_center + one_value, i_max, j_center), color)
+    _draw!(image, HorizontalLine(i_center, j_center + one_value, j_max), color)
 
     return nothing
 end

--- a/src/line.jl
+++ b/src/line.jl
@@ -30,15 +30,6 @@ function draw!(image::AbstractMatrix, shape::VerticalLine, color)
         return nothing
     end
 
-    i_min = shape.i_min
-    i_max = shape.i_max
-    j = shape.j
-
-    if i_min == i_max
-        draw!(image, Point(i_min, j), color)
-        return nothing
-    end
-
     draw_unchecked!(image, clip(shape, image), color)
 
     return nothing
@@ -55,15 +46,6 @@ function draw!(image::AbstractMatrix, shape::HorizontalLine, color)
     end
 
     if is_outbounds(shape, image)
-        return nothing
-    end
-
-    i = shape.i
-    j_min = shape.j_min
-    j_max = shape.j_max
-
-    if j_min == j_max
-        draw!(image, Point(i, j_min), color)
         return nothing
     end
 

--- a/src/line.jl
+++ b/src/line.jl
@@ -30,12 +30,12 @@ function draw!(image::AbstractMatrix, shape::VerticalLine, color)
         return nothing
     end
 
-    draw_unchecked!(image, clip(shape, image), color)
+    _draw!(image, clip(shape, image), color)
 
     return nothing
 end
 
-@inline function draw_unchecked!(image::AbstractMatrix, shape::VerticalLine, color)
+@inline function _draw!(image::AbstractMatrix, shape::VerticalLine, color)
     @inbounds image[shape.i_min:shape.i_max, shape.j] .= color
     return nothing
 end
@@ -49,12 +49,12 @@ function draw!(image::AbstractMatrix, shape::HorizontalLine, color)
         return nothing
     end
 
-    draw_unchecked!(image, clip(shape, image), color)
+    _draw!(image, clip(shape, image), color)
 
     return nothing
 end
 
-@inline function draw_unchecked!(image::AbstractMatrix, shape::HorizontalLine, color)
+@inline function _draw!(image::AbstractMatrix, shape::HorizontalLine, color)
     @inbounds image[shape.i, shape.j_min:shape.j_max] .= color
     return nothing
 end
@@ -91,6 +91,8 @@ function draw!(image::AbstractMatrix, shape::Line, color)
     return nothing
 end
 
+_draw!(image::AbstractMatrix, shape::Line, color) = _draw!(put_pixel_unchecked!, image, shape, color)
+
 function _draw!(f::Function, image::AbstractMatrix, shape::Line{I}, color) where {I}
     i1 = shape.point1.i
     j1 = shape.point1.j
@@ -107,43 +109,6 @@ function _draw!(f::Function, image::AbstractMatrix, shape::Line{I}, color) where
 
     while true
         f(image, i1, j1, color)
-
-        if (i1 == i2 && j1 == j2)
-            break
-        end
-
-        e2 = convert(I, 2) * err
-
-        if (e2 >= dj)
-            err += dj
-            i1 += si
-        end
-
-        if (e2 <= di)
-            err += di
-            j1 += sj
-        end
-    end
-
-    return nothing
-end
-
-function draw_unchecked!(image::AbstractMatrix, shape::Line{I}, color) where {I}
-    i1 = shape.point1.i
-    j1 = shape.point1.j
-    i2 = shape.point2.i
-    j2 = shape.point2.j
-
-    one_value = one(I)
-
-    di = abs(i2 - i1)
-    dj = -abs(j2 - j1)
-    si = i1 < i2 ? one_value : -one_value
-    sj = j1 < j2 ? one_value : -one_value
-    err = di + dj
-
-    while true
-        put_pixel_unchecked!(image, i1, j1, color)
 
         if (i1 == i2 && j1 == j2)
             break
@@ -184,45 +149,6 @@ function draw!(image::AbstractMatrix, shape::ThickLine{I}, color) where {I}
     end
 
     _draw!(f, image, Line(point1, point2), color)
-
-    return nothing
-end
-
-function draw_unchecked!(image::AbstractMatrix, shape::ThickLine{I}, color) where {I}
-    i1 = shape.point1.i
-    j1 = shape.point1.j
-    i2 = shape.point2.i
-    j2 = shape.point2.j
-    diameter = shape.diameter
-    radius = diameter ÷ 2
-
-    one_value = one(I)
-
-    di = abs(i2 - i1)
-    dj = -abs(j2 - j1)
-    si = i1 < i2 ? one_value : -one_value
-    sj = j1 < j2 ? one_value : -one_value
-    err = di + dj
-
-    while true
-        draw!(image, FilledCircle(Point(i1 - radius, j1 - radius), diameter), color)
-
-        if (i1 == i2 && j1 == j2)
-            break
-        end
-
-        e2 = convert(I, 2) * err
-
-        if (e2 >= dj)
-            err += dj
-            i1 += si
-        end
-
-        if (e2 <= di)
-            err += di
-            j1 += sj
-        end
-    end
 
     return nothing
 end

--- a/src/line.jl
+++ b/src/line.jl
@@ -64,38 +64,24 @@ end
 end
 
 function draw!(image::AbstractMatrix, shape::HorizontalLine, color)
+    if !is_valid(shape)
+        return nothing
+    end
+
+    if is_outbounds(shape, image)
+        return nothing
+    end
+
     i = shape.i
     j_min = shape.j_min
     j_max = shape.j_max
-
-    if j_min > j_max
-        return nothing
-    end
-
-    i_min_image = firstindex(image, 1)
-    i_max_image = lastindex(image, 1)
-
-    j_min_image = firstindex(image, 2)
-    j_max_image = lastindex(image, 2)
-
-    if i < i_min_image || i > i_max_image || j_max < j_min_image || j_min > j_max_image
-        return nothing
-    end
 
     if j_min == j_max
         draw!(image, Point(i, j_min), color)
         return nothing
     end
 
-    if j_min < j_min_image
-        j_min = j_min_image
-    end
-
-    if j_max > j_max_image
-        j_max = j_max_image
-    end
-
-    draw_unchecked!(image, HorizontalLine(i, j_min, j_max), color)
+    draw_unchecked!(image, clip(shape, image), color)
 
     return nothing
 end
@@ -343,4 +329,42 @@ function get_bounding_box(shape::ThickLine{I}) where {I}
     end
 
     return Rectangle(Point(i_min, j_min), i_diff + diameter, j_diff + diameter)
+end
+
+is_valid(shape::HorizontalLine) = shape.j_min <= shape.j_max
+
+function is_outbounds(shape::HorizontalLine, image::AbstractMatrix)
+    i = shape.i
+    j_min = shape.j_min
+    j_max = shape.j_max
+
+    i_min_image = firstindex(image, 1)
+    i_max_image = lastindex(image, 1)
+
+    j_min_image = firstindex(image, 2)
+    j_max_image = lastindex(image, 2)
+
+    return i < i_min_image || i > i_max_image || j_max < j_min_image || j_min > j_max_image
+end
+
+function clip(shape::HorizontalLine, image::AbstractMatrix)
+    i = shape.i
+    j_min = shape.j_min
+    j_max = shape.j_max
+
+    i_min_image = firstindex(image, 1)
+    i_max_image = lastindex(image, 1)
+
+    j_min_image = firstindex(image, 2)
+    j_max_image = lastindex(image, 2)
+
+    if j_min < j_min_image
+        j_min = j_min_image
+    end
+
+    if j_max > j_max_image
+        j_max = j_max_image
+    end
+
+    return HorizontalLine(i, j_min, j_max)
 end

--- a/src/line.jl
+++ b/src/line.jl
@@ -22,38 +22,24 @@ struct ThickLine{I <: Integer} <: AbstractShape
 end
 
 function draw!(image::AbstractMatrix, shape::VerticalLine, color)
+    if !is_valid(shape)
+        return nothing
+    end
+
+    if is_outbounds(shape, image)
+        return nothing
+    end
+
     i_min = shape.i_min
     i_max = shape.i_max
     j = shape.j
-
-    if i_min > i_max
-        return nothing
-    end
-
-    i_min_image = firstindex(image, 1)
-    i_max_image = lastindex(image, 1)
-
-    j_min_image = firstindex(image, 2)
-    j_max_image = lastindex(image, 2)
-
-    if i_max < i_min_image || i_min > i_max_image || j < j_min_image || j > j_max_image
-        return nothing
-    end
 
     if i_min == i_max
         draw!(image, Point(i_min, j), color)
         return nothing
     end
 
-    if i_min < i_min_image
-        i_min = i_min_image
-    end
-
-    if i_max > i_max_image
-        i_max = i_max_image
-    end
-
-    draw_unchecked!(image, VerticalLine(i_min, i_max, j), color)
+    draw_unchecked!(image, clip(shape, image), color)
 
     return nothing
 end
@@ -330,6 +316,52 @@ function get_bounding_box(shape::ThickLine{I}) where {I}
 
     return Rectangle(Point(i_min, j_min), i_diff + diameter, j_diff + diameter)
 end
+
+#####
+##### VerticalLine
+#####
+
+is_valid(shape::VerticalLine) = shape.i_min <= shape.i_max
+
+function is_outbounds(shape::VerticalLine, image::AbstractMatrix)
+    i_min = shape.i_min
+    i_max = shape.i_max
+    j = shape.j
+
+    i_min_image = firstindex(image, 1)
+    i_max_image = lastindex(image, 1)
+
+    j_min_image = firstindex(image, 2)
+    j_max_image = lastindex(image, 2)
+
+    return i_max < i_min_image || i_min > i_max_image || j < j_min_image || j > j_max_image
+end
+
+function clip(shape::VerticalLine, image::AbstractMatrix)
+    i_min = shape.i_min
+    i_max = shape.i_max
+    j = shape.j
+
+    i_min_image = firstindex(image, 1)
+    i_max_image = lastindex(image, 1)
+
+    j_min_image = firstindex(image, 2)
+    j_max_image = lastindex(image, 2)
+
+    if i_min < i_min_image
+        i_min = i_min_image
+    end
+
+    if i_max > i_max_image
+        i_max = i_max_image
+    end
+
+    return VerticalLine(i_min, i_max, j)
+end
+
+#####
+##### HorizontalLine
+#####
 
 is_valid(shape::HorizontalLine) = shape.j_min <= shape.j_max
 

--- a/src/rectangle.jl
+++ b/src/rectangle.jl
@@ -76,10 +76,10 @@ function draw_unchecked!(image::AbstractMatrix, shape::Rectangle{I}, color) wher
     j_min_plus_1 = j_min + one_value
     j_max_minus_1 = j_max - one_value
 
-    draw_unchecked!(image, VerticalLine(i_min, i_max, j_min), color)
-    draw_unchecked!(image, HorizontalLine(i_min, j_min_plus_1, j_max_minus_1), color)
-    draw_unchecked!(image, HorizontalLine(i_max, j_min_plus_1, j_max_minus_1), color)
-    draw_unchecked!(image, VerticalLine(i_min, i_max, j_max), color)
+    _draw!(image, VerticalLine(i_min, i_max, j_min), color)
+    _draw!(image, HorizontalLine(i_min, j_min_plus_1, j_max_minus_1), color)
+    _draw!(image, HorizontalLine(i_max, j_min_plus_1, j_max_minus_1), color)
+    _draw!(image, VerticalLine(i_min, i_max, j_max), color)
 
     return nothing
 end


### PR DESCRIPTION
1. Add `is_valid`, `is_outbounds`, and `clip` functions for `VerticalLine` and `HorizontalLine`.
2. Replace `draw_unchecked!` with `_draw!` for `VerticalLine`, `HorizontalLine`, `Line` and `ThickLine`.