### PR TITLE
add assertions for is_valid(shape)

### DIFF
--- a/src/circle.jl
+++ b/src/circle.jl
@@ -311,9 +311,7 @@ function draw!(image::AbstractMatrix, shape::Circle, color)
     zero_value = zero(I)
     one_value = one(I)
 
-    if !is_valid(shape)
-        return nothing
-    end
+    @assert is_valid(shape) "Cannot draw invalid shape $(shape)"
 
     i_min = i_position
     j_min = j_position
@@ -447,9 +445,7 @@ function draw!(image::AbstractMatrix, shape::FilledCircle, color)
     zero_value = zero(I)
     one_value = one(I)
 
-    if !is_valid(shape)
-        return nothing
-    end
+    @assert is_valid(shape) "Cannot draw invalid shape $(shape)"
 
     i_min = i_position
     j_min = j_position
@@ -562,9 +558,7 @@ function draw!(image::AbstractMatrix, shape::ThickCircle, color)
     zero_value = zero(I)
     one_value = one(I)
 
-    if !is_valid(shape)
-        return nothing
-    end
+    @assert is_valid(shape) "Cannot draw invalid shape $(shape)"
 
     i_min = i_position
     j_min = j_position

--- a/src/cross.jl
+++ b/src/cross.jl
@@ -47,9 +47,7 @@ function draw!(image::AbstractMatrix, shape::Cross, color)
     zero_value = zero(I)
     one_value = one(I)
 
-    if !is_valid(shape)
-        return nothing
-    end
+    @assert is_valid(shape) "Cannot draw invalid shape $(shape)"
 
     if is_outbounds(shape, image)
         return nothing
@@ -110,9 +108,7 @@ function draw!(image::AbstractMatrix, shape::HollowCross, color)
     zero_value = zero(I)
     one_value = one(I)
 
-    if !is_valid(shape)
-        return nothing
-    end
+    @assert is_valid(shape) "Cannot draw invalid shape $(shape)"
 
     if is_outbounds(shape, image)
         return nothing

--- a/src/line.jl
+++ b/src/line.jl
@@ -64,9 +64,7 @@ function clip(shape::VerticalLine, image::AbstractMatrix)
 end
 
 function draw!(image::AbstractMatrix, shape::VerticalLine, color)
-    if !is_valid(shape)
-        return nothing
-    end
+    @assert is_valid(shape) "Cannot draw invalid shape $(shape)"
 
     if is_outbounds(shape, image)
         return nothing
@@ -127,9 +125,7 @@ function clip(shape::HorizontalLine, image::AbstractMatrix)
 end
 
 function draw!(image::AbstractMatrix, shape::HorizontalLine, color)
-    if !is_valid(shape)
-        return nothing
-    end
+    @assert is_valid(shape) "Cannot draw invalid shape $(shape)"
 
     if is_outbounds(shape, image)
         return nothing
@@ -259,9 +255,7 @@ end
 is_valid(shape::ThickLine) = shape.diameter > zero(shape.diameter)
 
 function draw!(image::AbstractMatrix, shape::ThickLine, color)
-    if !is_valid(shape)
-        return nothing
-    end
+    @assert is_valid(shape) "Cannot draw invalid shape $(shape)"
 
     point1 = shape.point1
     point2 = shape.point2

--- a/src/rectangle.jl
+++ b/src/rectangle.jl
@@ -77,9 +77,7 @@ function draw!(image::AbstractMatrix, shape::Rectangle, color)
     I = typeof(height)
     one_value = one(I)
 
-    if !is_valid(shape)
-        return nothing
-    end
+    @assert is_valid(shape) "Cannot draw invalid shape $(shape)"
 
     if is_outbounds(shape, image)
         return nothing
@@ -158,9 +156,7 @@ function draw!(image::AbstractMatrix, shape::ThickRectangle, color)
     I = typeof(height)
     one_value = one(I)
 
-    if !is_valid(shape)
-        return nothing
-    end
+    @assert is_valid(shape) "Cannot draw invalid shape $(shape)"
 
     if is_outbounds(shape, image)
         return nothing
@@ -267,9 +263,7 @@ function draw!(image::AbstractMatrix, shape::FilledRectangle, color)
     I = typeof(height)
     one_value = one(I)
 
-    if !is_valid(shape)
-        return nothing
-    end
+    @assert is_valid(shape) "Cannot draw invalid shape $(shape)"
 
     if is_outbounds(shape, image)
         return nothing


### PR DESCRIPTION
1. Add assertions for `is_valid(shape)` wherever necessary. This breaks some tests.