### PR TITLE
update _draw! to behave like an iterator and take a function as an argument

### DIFF
--- a/src/background.jl
+++ b/src/background.jl
@@ -1,8 +1,8 @@
 struct Background <: AbstractShape end
 
-@inline draw!(image::AbstractMatrix, shape::Background, color) = _draw!(image, shape, color)
+draw!(image::AbstractMatrix, shape::Background, color) = _draw!(image, shape, color)
 
-@inline function _draw!(image::AbstractMatrix, shape::Background, color)
+function _draw!(image::AbstractMatrix, shape::Background, color)
     fill!(image, color)
     return nothing
 end

--- a/src/background.jl
+++ b/src/background.jl
@@ -6,3 +6,13 @@ struct Background <: AbstractShape end
     fill!(image, color)
     return nothing
 end
+
+function _draw!(f::Function, image::AbstractMatrix, shape::Background, color)
+    for j in axes(image, 2)
+        for i in axes(image, 1)
+            f(image, i, j, color)
+        end
+    end
+
+    return nothing
+end

--- a/src/character.jl
+++ b/src/character.jl
@@ -38,7 +38,9 @@ function draw!(image::AbstractMatrix, shape::Character, color)
     return nothing
 end
 
-function _draw!(image::AbstractMatrix, shape::Character, color)
+_draw!(image::AbstractMatrix, shape::Character, color) = _draw!(put_pixel_unchecked!, image, shape, color)
+
+function _draw!(f::Function, image::AbstractMatrix, shape::Character, color)
     position = shape.position
     char = shape.char
     font = shape.font
@@ -49,7 +51,7 @@ function _draw!(image::AbstractMatrix, shape::Character, color)
 
     bitmap_shape = Bitmap(position, @view bitmap[:, :, k])
 
-    _draw!(image, bitmap_shape, color)
+    _draw!(f, image, bitmap_shape, color)
 
     return nothing
 end

--- a/src/circle.jl
+++ b/src/circle.jl
@@ -34,7 +34,7 @@ struct EvenSymmetricLines8{I <: Integer} <: AbstractShape
     j::I
 end
 
-struct StandardCircleOctant{I <: Integer} <: AbstractShape
+struct CircleOctant{I <: Integer} <: AbstractShape
     center::Point{I}
     radius::I
 end
@@ -353,14 +353,14 @@ end
 get_bounding_box(shape::AbstractCircle) = Rectangle(shape.position, shape.diameter, shape.diameter)
 
 #####
-##### StandardCircleOctant
+##### CircleOctant
 #####
 
-draw!(image::AbstractMatrix, shape::StandardCircleOctant, color) = _draw!(put_pixel!, image, shape, color)
+draw!(image::AbstractMatrix, shape::CircleOctant, color) = _draw!(put_pixel!, image, shape, color)
 
-_draw!(image::AbstractMatrix, shape::StandardCircleOctant, color) = _draw!(put_pixel_unchecked!, image, shape, color)
+_draw!(image::AbstractMatrix, shape::CircleOctant, color) = _draw!(put_pixel_unchecked!, image, shape, color)
 
-function _draw!(f::Function, image::AbstractMatrix, shape::StandardCircleOctant, color)
+function _draw!(f::Function, image::AbstractMatrix, shape::CircleOctant, color)
     center = shape.center
     radius = shape.radius
 
@@ -419,7 +419,7 @@ function _draw!(f::Function, image::AbstractMatrix, shape::OddCircle, color)
 
     center, radius = get_center_radius(shape)
 
-    _draw!(image, StandardCircleOctant(center, radius), color) do image, i, j, color
+    _draw!(image, CircleOctant(center, radius), color) do image, i, j, color
         _draw!(f, image, OddSymmetricPoints8(center, Point(i, j)), color)
     end
 
@@ -454,7 +454,7 @@ function _draw!(f::Function, image::AbstractMatrix, shape::EvenCircle, color)
 
     center, radius = get_center_radius(shape)
 
-    _draw!(image, StandardCircleOctant(center, radius), color) do image, i, j, color
+    _draw!(image, CircleOctant(center, radius), color) do image, i, j, color
         _draw!(f, image, EvenSymmetricPoints8(center, Point(i, j)), color)
     end
 
@@ -517,7 +517,7 @@ function _draw!(f::Function, image::AbstractMatrix, shape::OddFilledCircle, colo
 
     center, radius = get_center_radius(shape)
 
-    _draw!(image, StandardCircleOctant(center, radius), color) do image, i, j, color
+    _draw!(image, CircleOctant(center, radius), color) do image, i, j, color
         _draw!(f, image, OddSymmetricVerticalLines4(center, Point(i, j)), color)
     end
 
@@ -550,7 +550,7 @@ function _draw!(f::Function, image::AbstractMatrix, shape::EvenFilledCircle, col
 
     center, radius = get_center_radius(shape)
 
-    _draw!(image, StandardCircleOctant(center, radius), color) do image, i, j, color
+    _draw!(image, CircleOctant(center, radius), color) do image, i, j, color
         _draw!(f, image, EvenSymmetricVerticalLines4(center, Point(i, j)), color)
     end
 

--- a/src/circle.jl
+++ b/src/circle.jl
@@ -86,10 +86,7 @@ end
 ##### EvenSymmetricPoints8
 #####
 
-function draw!(image::AbstractMatrix, shape::EvenSymmetricPoints8, color)
-    _draw!(put_pixel!, image, shape, color)
-    return nothing
-end
+draw!(image::AbstractMatrix, shape::EvenSymmetricPoints8, color) = _draw!(put_pixel!, image, shape, color)
 
 _draw!(image::AbstractMatrix, shape::EvenSymmetricPoints8, color) = _draw!(put_pixel_unchecked!, image, shape, color)
 
@@ -121,10 +118,7 @@ end
 ##### OddSymmetricPoints8
 #####
 
-function draw!(image::AbstractMatrix, shape::OddSymmetricPoints8, color)
-    _draw!(put_pixel!, image, shape, color)
-    return nothing
-end
+draw!(image::AbstractMatrix, shape::OddSymmetricPoints8, color) = _draw!(put_pixel!, image, shape, color)
 
 _draw!(image::AbstractMatrix, shape::OddSymmetricPoints8, color) = _draw!(put_pixel_unchecked!, image, shape, color)
 

--- a/src/circle.jl
+++ b/src/circle.jl
@@ -34,6 +34,11 @@ struct OddSymmetricLines8{I <: Integer} <: AbstractShape
     j_outer::I
 end
 
+struct StandardCircleOctant{I <: Integer} <: AbstractShape
+    center::Point{I}
+    radius::I
+end
+
 struct Circle{I <: Integer} <: AbstractCircle
     position::Point{I}
     diameter::I
@@ -350,6 +355,45 @@ function _draw!(image::AbstractMatrix, shape::Circle, color)
         _draw!(image, EvenCircle(position, diameter), color)
     else
         _draw!(image, OddCircle(position, diameter), color)
+    end
+
+    return nothing
+end
+
+#####
+##### StandardCircleOctant
+#####
+
+draw!(image::AbstractMatrix, shape::StandardCircleOctant, color) = _draw!(put_pixel!, image, shape, color)
+
+_draw!(image::AbstractMatrix, shape::StandardCircleOctant, color) = _draw!(put_pixel_unchecked!, image, shape, color)
+
+function _draw!(f::Function, image::AbstractMatrix, shape::StandardCircleOctant, color)
+    center = shape.center
+    radius = shape.radius
+
+    I = typeof(radius)
+
+    i_center = center.i
+    j_center = center.j
+
+    i = radius
+    j = zero(I)
+
+    f(image, i_center + i, j_center + j, color)
+
+    constant = convert(I, 3) - convert(I, 2) * radius * radius
+
+    while i > j + one(I)
+        d = convert(I, 2) * i * i + convert(I, 2) * j * j + convert(I, 4) * j - convert(I, 2) * i + constant
+
+        j += one(I)
+
+        if d > zero(I)
+            i -= one(I)
+        end
+
+        f(image, i_center + i, j_center + j, color)
     end
 
     return nothing

--- a/src/circle.jl
+++ b/src/circle.jl
@@ -257,7 +257,9 @@ function draw!(image::AbstractMatrix, shape::EvenSymmetricLines8, color)
     return nothing
 end
 
-function _draw!(image::AbstractMatrix, shape::EvenSymmetricLines8, color)
+_draw!(image::AbstractMatrix, shape::EvenSymmetricLines8, color) = _draw!(put_pixel_unchecked!, image, shape, color)
+
+function _draw!(f::Function, image::AbstractMatrix, shape::EvenSymmetricLines8, color)
     center = shape.center
     i = shape.i
     j_inner = shape.j_inner
@@ -269,14 +271,14 @@ function _draw!(image::AbstractMatrix, shape::EvenSymmetricLines8, color)
     I = typeof(i_center)
     one_value = one(I)
 
-    _draw!(image, HorizontalLine(i_center - i, j_center - j_outer, j_center - j_inner), color)
-    _draw!(image, HorizontalLine(i_center + i - one_value, j_center - j_outer, j_center - j_inner), color)
-    _draw!(image, VerticalLine(i_center - j_outer, i_center - j_inner, j_center - i), color)
-    _draw!(image, VerticalLine(i_center + j_inner - one_value, i_center + j_outer - one_value, j_center - i), color)
-    _draw!(image, VerticalLine(i_center - j_outer, i_center - j_inner, j_center + i - one_value), color)
-    _draw!(image, VerticalLine(i_center + j_inner - one_value, i_center + j_outer - one_value, j_center + i - one_value), color)
-    _draw!(image, HorizontalLine(i_center - i, j_center + j_inner - one_value, j_center + j_outer - one_value), color)
-    _draw!(image, HorizontalLine(i_center + i - one_value, j_center + j_inner - one_value, j_center + j_outer - one_value), color)
+    _draw!(f, image, HorizontalLine(i_center - i, j_center - j_outer, j_center - j_inner), color)
+    _draw!(f, image, HorizontalLine(i_center + i - one_value, j_center - j_outer, j_center - j_inner), color)
+    _draw!(f, image, VerticalLine(i_center - j_outer, i_center - j_inner, j_center - i), color)
+    _draw!(f, image, VerticalLine(i_center + j_inner - one_value, i_center + j_outer - one_value, j_center - i), color)
+    _draw!(f, image, VerticalLine(i_center - j_outer, i_center - j_inner, j_center + i - one_value), color)
+    _draw!(f, image, VerticalLine(i_center + j_inner - one_value, i_center + j_outer - one_value, j_center + i - one_value), color)
+    _draw!(f, image, HorizontalLine(i_center - i, j_center + j_inner - one_value, j_center + j_outer - one_value), color)
+    _draw!(f, image, HorizontalLine(i_center + i - one_value, j_center + j_inner - one_value, j_center + j_outer - one_value), color)
 
     return nothing
 end
@@ -306,7 +308,9 @@ function draw!(image::AbstractMatrix, shape::OddSymmetricLines8, color)
     return nothing
 end
 
-function _draw!(image::AbstractMatrix, shape::OddSymmetricLines8, color)
+_draw!(image::AbstractMatrix, shape::OddSymmetricLines8, color) = _draw!(put_pixel_unchecked!, image, shape, color)
+
+function _draw!(f::Function, image::AbstractMatrix, shape::OddSymmetricLines8, color)
     center = shape.center
     i = shape.i
     j_inner = shape.j_inner
@@ -315,14 +319,14 @@ function _draw!(image::AbstractMatrix, shape::OddSymmetricLines8, color)
     i_center = center.i
     j_center = center.j
 
-    _draw!(image, HorizontalLine(i_center - i, j_center - j_outer, j_center - j_inner), color)
-    _draw!(image, HorizontalLine(i_center + i, j_center - j_outer, j_center - j_inner), color)
-    _draw!(image, VerticalLine(i_center - j_outer, i_center - j_inner, j_center - i), color)
-    _draw!(image, VerticalLine(i_center + j_inner, i_center + j_outer, j_center - i), color)
-    _draw!(image, VerticalLine(i_center - j_outer, i_center - j_inner, j_center + i), color)
-    _draw!(image, VerticalLine(i_center + j_inner, i_center + j_outer, j_center + i), color)
-    _draw!(image, HorizontalLine(i_center - i, j_center + j_inner, j_center + j_outer), color)
-    _draw!(image, HorizontalLine(i_center + i, j_center + j_inner, j_center + j_outer), color)
+    _draw!(f, image, HorizontalLine(i_center - i, j_center - j_outer, j_center - j_inner), color)
+    _draw!(f, image, HorizontalLine(i_center + i, j_center - j_outer, j_center - j_inner), color)
+    _draw!(f, image, VerticalLine(i_center - j_outer, i_center - j_inner, j_center - i), color)
+    _draw!(f, image, VerticalLine(i_center + j_inner, i_center + j_outer, j_center - i), color)
+    _draw!(f, image, VerticalLine(i_center - j_outer, i_center - j_inner, j_center + i), color)
+    _draw!(f, image, VerticalLine(i_center + j_inner, i_center + j_outer, j_center + i), color)
+    _draw!(f, image, HorizontalLine(i_center - i, j_center + j_inner, j_center + j_outer), color)
+    _draw!(f, image, HorizontalLine(i_center + i, j_center + j_inner, j_center + j_outer), color)
 
     return nothing
 end

--- a/src/circle.jl
+++ b/src/circle.jl
@@ -478,14 +478,16 @@ function draw!(image::AbstractMatrix, shape::Circle, color)
     return nothing
 end
 
-function _draw!(image::AbstractMatrix, shape::Circle, color)
+_draw!(image::AbstractMatrix, shape::Circle, color) = _draw!(put_pixel_unchecked!, image, shape, color)
+
+function _draw!(f::Function, image::AbstractMatrix, shape::Circle, color)
     position = shape.position
     diameter = shape.diameter
 
     if iseven(diameter)
-        _draw!(image, EvenCircle(position, diameter), color)
+        _draw!(f, image, EvenCircle(position, diameter), color)
     else
-        _draw!(image, OddCircle(position, diameter), color)
+        _draw!(f, image, OddCircle(position, diameter), color)
     end
 
     return nothing
@@ -790,15 +792,17 @@ function draw!(image::AbstractMatrix, shape::ThickCircle, color)
     return nothing
 end
 
-function _draw!(image::AbstractMatrix, shape::ThickCircle, color)
+_draw!(image::AbstractMatrix, shape::ThickCircle, color) = _draw!(put_pixel_unchecked!, image, shape, color)
+
+function _draw!(f::Function, image::AbstractMatrix, shape::ThickCircle, color)
     position = shape.position
     diameter = shape.diameter
     thickness = shape.thickness
 
     if iseven(diameter)
-        _draw!(image, EvenThickCircle(position, diameter, thickness), color)
+        _draw!(f, image, EvenThickCircle(position, diameter, thickness), color)
     else
-        _draw!(image, OddThickCircle(position, diameter, thickness), color)
+        _draw!(f, image, OddThickCircle(position, diameter, thickness), color)
     end
 
     return nothing

--- a/src/circle.jl
+++ b/src/circle.jl
@@ -167,7 +167,9 @@ function draw!(image::AbstractMatrix, shape::EvenSymmetricVerticalLines4, color)
     return nothing
 end
 
-function _draw!(image::AbstractMatrix, shape::EvenSymmetricVerticalLines4, color)
+_draw!(image::AbstractMatrix, shape::EvenSymmetricVerticalLines4, color) = _draw!(put_pixel_unchecked!, image, shape, color)
+
+function _draw!(f::Function, image::AbstractMatrix, shape::EvenSymmetricVerticalLines4, color)
     center = shape.center
     point = shape.point
 
@@ -179,10 +181,10 @@ function _draw!(image::AbstractMatrix, shape::EvenSymmetricVerticalLines4, color
     I = typeof(i_center)
     one_value = one(I)
 
-    _draw!(image, VerticalLine(i_center - i, i_center + i - one_value, j_center - j), color)
-    _draw!(image, VerticalLine(i_center - j, i_center + j - one_value, j_center - i), color)
-    _draw!(image, VerticalLine(i_center - j, i_center + j - one_value, j_center + i - one_value), color)
-    _draw!(image, VerticalLine(i_center - i, i_center + i - one_value, j_center + j - one_value), color)
+    _draw!(f, image, VerticalLine(i_center - i, i_center + i - one_value, j_center - j), color)
+    _draw!(f, image, VerticalLine(i_center - j, i_center + j - one_value, j_center - i), color)
+    _draw!(f, image, VerticalLine(i_center - j, i_center + j - one_value, j_center + i - one_value), color)
+    _draw!(f, image, VerticalLine(i_center - i, i_center + i - one_value, j_center + j - one_value), color)
 
     return nothing
 end
@@ -208,7 +210,9 @@ function draw!(image::AbstractMatrix, shape::OddSymmetricVerticalLines4, color)
     return nothing
 end
 
-function _draw!(image::AbstractMatrix, shape::OddSymmetricVerticalLines4, color)
+_draw!(image::AbstractMatrix, shape::OddSymmetricVerticalLines4, color) = _draw!(put_pixel_unchecked!, image, shape, color)
+
+function _draw!(f::Function, image::AbstractMatrix, shape::OddSymmetricVerticalLines4, color)
     center = shape.center
     point = shape.point
 
@@ -217,10 +221,10 @@ function _draw!(image::AbstractMatrix, shape::OddSymmetricVerticalLines4, color)
     i = point.i
     j = point.j
 
-    _draw!(image, VerticalLine(i_center - i, i_center + i, j_center - j), color)
-    _draw!(image, VerticalLine(i_center - j, i_center + j, j_center - i), color)
-    _draw!(image, VerticalLine(i_center - j, i_center + j, j_center + i), color)
-    _draw!(image, VerticalLine(i_center - i, i_center + i, j_center + j), color)
+    _draw!(f, image, VerticalLine(i_center - i, i_center + i, j_center - j), color)
+    _draw!(f, image, VerticalLine(i_center - j, i_center + j, j_center - i), color)
+    _draw!(f, image, VerticalLine(i_center - j, i_center + j, j_center + i), color)
+    _draw!(f, image, VerticalLine(i_center - i, i_center + i, j_center + j), color)
 
     return nothing
 end

--- a/src/circle.jl
+++ b/src/circle.jl
@@ -22,16 +22,16 @@ end
 
 struct EvenSymmetricLines8{I <: Integer} <: AbstractShape
     center::Point{I}
-    i::I
-    j_inner::I
-    j_outer::I
+    i_inner::I
+    i_outer::I
+    j::I
 end
 
 struct OddSymmetricLines8{I <: Integer} <: AbstractShape
     center::Point{I}
-    i::I
-    j_inner::I
-    j_outer::I
+    i_inner::I
+    i_outer::I
+    j::I
 end
 
 struct StandardCircleOctant{I <: Integer} <: AbstractShape
@@ -72,6 +72,12 @@ end
 struct ThickCircle{I <: Integer} <: AbstractCircle
     position::Point{I}
     diameter::I
+    thickness::I
+end
+
+struct ThickCircleOctant{I <: Integer} <: AbstractShape
+    center::Point{I}
+    radius::I
     thickness::I
 end
 
@@ -220,24 +226,27 @@ _draw!(image::AbstractMatrix, shape::EvenSymmetricLines8, color) = _draw!(put_pi
 
 function _draw!(f::Function, image::AbstractMatrix, shape::EvenSymmetricLines8, color)
     center = shape.center
-    i = shape.i
-    j_inner = shape.j_inner
-    j_outer = shape.j_outer
+    i_inner = shape.i_inner
+    i_outer = shape.i_outer
+    j = shape.j
+
+    I = typeof(i_inner)
 
     i_center = center.i
     j_center = center.j
 
-    I = typeof(i_center)
-    one_value = one(I)
+    i_inner_relative = i_inner - i_center
+    i_outer_relative = i_outer - i_center
+    j_relative = j - j_center
 
-    _draw!(f, image, HorizontalLine(i_center - i, j_center - j_outer, j_center - j_inner), color)
-    _draw!(f, image, HorizontalLine(i_center + i - one_value, j_center - j_outer, j_center - j_inner), color)
-    _draw!(f, image, VerticalLine(i_center - j_outer, i_center - j_inner, j_center - i), color)
-    _draw!(f, image, VerticalLine(i_center + j_inner - one_value, i_center + j_outer - one_value, j_center - i), color)
-    _draw!(f, image, VerticalLine(i_center - j_outer, i_center - j_inner, j_center + i - one_value), color)
-    _draw!(f, image, VerticalLine(i_center + j_inner - one_value, i_center + j_outer - one_value, j_center + i - one_value), color)
-    _draw!(f, image, HorizontalLine(i_center - i, j_center + j_inner - one_value, j_center + j_outer - one_value), color)
-    _draw!(f, image, HorizontalLine(i_center + i - one_value, j_center + j_inner - one_value, j_center + j_outer - one_value), color)
+    _draw!(f, image, HorizontalLine(i_center - j_relative, j_center - i_outer_relative, j_center - i_inner_relative), color)
+    _draw!(f, image, HorizontalLine(i_center + j_relative - one(I), j_center - i_outer_relative, j_center - i_inner_relative), color)
+    _draw!(f, image, VerticalLine(i_center - i_outer_relative, i_center - i_inner_relative, j_center - j_relative), color)
+    _draw!(f, image, VerticalLine(i_center + i_inner_relative - one(I), i_center + i_outer_relative - one(I), j_center - j_relative), color)
+    _draw!(f, image, VerticalLine(i_center - i_outer_relative, i_center - i_inner_relative, j_center + j_relative - one(I)), color)
+    _draw!(f, image, VerticalLine(i_center + i_inner_relative - one(I), i_center + i_outer_relative - one(I), j_center + j_relative - one(I)), color)
+    _draw!(f, image, HorizontalLine(i_center - j_relative, j_center + i_inner_relative - one(I), j_center + i_outer_relative - one(I)), color)
+    _draw!(f, image, HorizontalLine(i_center + j_relative - one(I), j_center + i_inner_relative - one(I), j_center + i_outer_relative - one(I)), color)
 
     return nothing
 end
@@ -252,21 +261,25 @@ _draw!(image::AbstractMatrix, shape::OddSymmetricLines8, color) = _draw!(put_pix
 
 function _draw!(f::Function, image::AbstractMatrix, shape::OddSymmetricLines8, color)
     center = shape.center
-    i = shape.i
-    j_inner = shape.j_inner
-    j_outer = shape.j_outer
+    i_inner = shape.i_inner
+    i_outer = shape.i_outer
+    j = shape.j
 
     i_center = center.i
     j_center = center.j
 
-    _draw!(f, image, HorizontalLine(i_center - i, j_center - j_outer, j_center - j_inner), color)
-    _draw!(f, image, HorizontalLine(i_center + i, j_center - j_outer, j_center - j_inner), color)
-    _draw!(f, image, VerticalLine(i_center - j_outer, i_center - j_inner, j_center - i), color)
-    _draw!(f, image, VerticalLine(i_center + j_inner, i_center + j_outer, j_center - i), color)
-    _draw!(f, image, VerticalLine(i_center - j_outer, i_center - j_inner, j_center + i), color)
-    _draw!(f, image, VerticalLine(i_center + j_inner, i_center + j_outer, j_center + i), color)
-    _draw!(f, image, HorizontalLine(i_center - i, j_center + j_inner, j_center + j_outer), color)
-    _draw!(f, image, HorizontalLine(i_center + i, j_center + j_inner, j_center + j_outer), color)
+    i_inner_relative = i_inner - i_center
+    i_outer_relative = i_outer - i_center
+    j_relative = j - j_center
+
+    _draw!(f, image, HorizontalLine(i_center - j_relative, j_center - i_outer_relative, j_center - i_inner_relative), color)
+    _draw!(f, image, HorizontalLine(i_center + j_relative, j_center - i_outer_relative, j_center - i_inner_relative), color)
+    _draw!(f, image, VerticalLine(i_center - i_outer_relative, i_center - i_inner_relative, j_center - j_relative), color)
+    _draw!(f, image, VerticalLine(i_center + i_inner_relative, i_center + i_outer_relative, j_center - j_relative), color)
+    _draw!(f, image, VerticalLine(i_center - i_outer_relative, i_center - i_inner_relative, j_center + j_relative), color)
+    _draw!(f, image, VerticalLine(i_center + i_inner_relative, i_center + i_outer_relative, j_center + j_relative), color)
+    _draw!(f, image, HorizontalLine(i_center - j_relative, j_center + i_inner_relative, j_center + i_outer_relative), color)
+    _draw!(f, image, HorizontalLine(i_center + j_relative, j_center + i_inner_relative, j_center + i_outer_relative), color)
 
     return nothing
 end
@@ -621,6 +634,91 @@ function _draw!(image::AbstractMatrix, shape::ThickCircle, color)
 end
 
 #####
+##### ThickCircleOctant
+#####
+
+function is_valid(shape::ThickCircleOctant)
+    center = shape.center
+    radius = shape.radius
+    thickness = shape.thickness
+
+    I = typeof(radius)
+
+    return radius >= zero(I) && thickness > zero(I) && thickness <= radius + one(I)
+end
+
+function draw!(image::AbstractMatrix, shape::ThickCircleOctant, color)
+    @assert is_valid(shape) "Cannot draw invalid shape $(shape)"
+
+    if is_inbounds(shape, image)
+        _draw!(put_pixel_unchecked!, image, shape, color)
+    else
+        _draw!(put_pixel!, image, shape, color)
+    end
+
+    return nothing
+end
+
+_draw!(image::AbstractMatrix, shape::ThickCircleOctant, color) = _draw!(put_pixel_unchecked!, image, shape, color)
+
+function _draw!(f::Function, image::AbstractMatrix, shape::ThickCircleOctant, color)
+    center = shape.center
+    radius = shape.radius
+    thickness = shape.thickness
+
+    I = typeof(radius)
+
+    i_center = center.i
+    j_center = center.j
+
+    radius_inner = radius - thickness + one(I)
+    radius_outer = radius
+
+    i_inner = radius_inner
+    j_inner = zero(I)
+
+    i_outer = radius_outer
+    j_outer = zero(I)
+
+    constant_inner = convert(I, 3) - convert(I, 2) * radius_inner * radius_inner
+    constant_outer = convert(I, 3) - convert(I, 2) * radius_outer * radius_outer
+
+    f(image, i_center + i_inner, j_center + j_inner, i_center + i_outer, j_center + j_outer, color)
+
+    while i_inner > j_inner + one(I)
+        d_inner = convert(I, 2) * i_inner * i_inner + convert(I, 2) * j_inner * j_inner + convert(I, 4) * j_inner - convert(I, 2) * i_inner + constant_inner
+        d_outer = convert(I, 2) * i_outer * i_outer + convert(I, 2) * j_outer * j_outer + convert(I, 4) * j_outer - convert(I, 2) * i_outer + constant_outer
+
+        j_inner += one(I)
+        j_outer += one(I)
+
+        if d_inner > zero(I)
+            i_inner -= one(I)
+        end
+
+        if d_outer > zero(I)
+            i_outer -= one(I)
+        end
+
+        f(image, i_center + i_inner, j_center + j_inner, i_center + i_outer, j_center + j_outer, color)
+    end
+
+    while i_outer > j_outer + one(I)
+        d_outer = convert(I, 2) * i_outer * i_outer + convert(I, 2) * j_outer * j_outer + convert(I, 4) * j_outer - convert(I, 2) * i_outer + constant_outer
+
+        j_outer += one(I)
+
+        if d_outer > zero(I)
+            i_outer -= one(I)
+        end
+
+        f(image, i_center + j_outer, j_center + j_outer, i_center + i_outer, j_center + j_outer, color)
+    end
+
+    return nothing
+end
+
+#####
 ##### OddThickCircle
 #####
 
@@ -636,56 +734,16 @@ end
 function draw!(image::AbstractMatrix, shape::OddThickCircle, color)
     @assert is_valid(shape) "Cannot draw invalid shape $(shape)"
 
-    if is_outbounds(shape, image)
-        return nothing
-    end
-
-    position = shape.position
-    diameter = shape.diameter
-    thickness = shape.thickness
-
-    I = typeof(diameter)
-
-    if diameter == one(I)
-        draw!(image, position, color)
-        return nothing
-    end
-
-    if thickness == one(I)
-        draw!(image, OddCircle(position, diameter), color)
-        return nothing
-    end
-
-    if convert(I, 2) * thickness >= diameter
-        draw!(image, OddFilledCircle(position, diameter), color)
-        return nothing
-    end
-
     if is_inbounds(shape, image)
-        _draw!(image, shape, color) do image, i_center, j_center, i, j_inner, j_outer, color
-             _draw!(image, OddSymmetricLines8(Point(i_center, j_center), i, j_inner, j_outer), color)
-        end
+        _draw!(put_pixel_unchecked!, image, shape, color)
     else
-        _draw!(image, shape, color) do image, i_center, j_center, i, j_inner, j_outer, color
-             draw!(image, OddSymmetricLines8(Point(i_center, j_center), i, j_inner, j_outer), color)
-        end
+        _draw!(put_pixel!, image, shape, color)
     end
 
     return nothing
 end
 
-function _draw!(image::AbstractMatrix, shape::OddThickCircle, color)
-    position = shape.position
-    diameter = shape.diameter
-
-    center = get_center(shape)
-
-    _draw!(image, shape, color) do image, _, _, i, j_inner, j_outer, color
-        _draw!(image, OddSymmetricLines8(center, i, j_inner, j_outer), color)
-    end
-
-    return nothing
-end
+_draw!(image::AbstractMatrix, shape::OddThickCircle, color) = _draw!(put_pixel_unchecked!, image, shape, color)
 
 function _draw!(f::Function, image::AbstractMatrix, shape::OddThickCircle, color)
     position = shape.position
@@ -694,61 +752,10 @@ function _draw!(f::Function, image::AbstractMatrix, shape::OddThickCircle, color
 
     I = typeof(diameter)
 
-    i_position = position.i
-    j_position = position.j
+    center, radius = get_center_radius(shape)
 
-    radius = diameter ÷ convert(I, 2)
-
-    i_center = i_position + radius
-    j_center = j_position + radius
-    center = Point(i_center, j_center)
-
-    i_position_inner = i_position + thickness - one(I)
-    j_position_inner = j_position + thickness - one(I)
-
-    diameter_inner = diameter - convert(I, 2) * (thickness - one(I))
-    radius_outer = radius
-    radius_inner = diameter_inner ÷ convert(I, 2)
-
-    i_inner = zero(I)
-    j_inner = radius_inner
-
-    i_outer = zero(I)
-    j_outer = radius_outer
-
-    f(image, i_center, j_center, i_outer, j_inner, j_outer, color)
-
-    constant_inner = convert(I, 3) - convert(I, 2) * radius_inner * radius_inner
-    constant_outer = convert(I, 3) - convert(I, 2) * radius_outer * radius_outer
-
-    while j_inner >= i_inner
-        d_inner = convert(I, 2) * j_inner * j_inner + convert(I, 2) * i_inner * i_inner + convert(I, 4) * i_inner - convert(I, 2) * j_inner + constant_inner
-        d_outer = convert(I, 2) * j_outer * j_outer + convert(I, 2) * i_outer * i_outer + convert(I, 4) * i_outer - convert(I, 2) * j_outer + constant_outer
-
-        i_inner += one(I)
-        i_outer += one(I)
-
-        if d_inner > zero(I)
-            j_inner -= one(I)
-        end
-
-        if d_outer > zero(I)
-            j_outer -= one(I)
-        end
-
-        f(image, i_center, j_center, i_outer, j_inner, j_outer, color)
-    end
-
-    while j_outer >= i_outer
-        d_outer = convert(I, 2) * j_outer * j_outer + convert(I, 2) * i_outer * i_outer + convert(I, 4) * i_outer - convert(I, 2) * j_outer + constant_outer
-
-        i_outer += one(I)
-
-        if d_outer > zero(I)
-            j_outer -= one(I)
-        end
-
-        f(image, i_center, j_center, i_outer, j_inner, j_outer, color)
+    _draw!(image, ThickCircleOctant(center, radius, thickness), color) do image, i1, j1, i2, j2, color
+        _draw!(f, image, OddSymmetricLines8(center, i1, i2, j1), color)
     end
 
     return nothing
@@ -770,62 +777,16 @@ end
 function draw!(image::AbstractMatrix, shape::EvenThickCircle, color)
     @assert is_valid(shape) "Cannot draw invalid shape $(shape)"
 
-    if is_outbounds(shape, image)
-        return nothing
-    end
-
-    position = shape.position
-    diameter = shape.diameter
-    thickness = shape.thickness
-
-    I = typeof(diameter)
-
-    if diameter == convert(I, 2)
-        draw!(image, FilledRectangle(position, convert(I, 2), convert(I, 2)), color)
-        return nothing
-    end
-
-    if thickness == one(I)
-        draw!(image, EvenCircle(position, diameter), color)
-        return nothing
-    end
-
-    if convert(I, 2) * thickness == diameter
-        draw!(image, EvenFilledCircle(position, diameter), color)
-        return nothing
-    end
-
     if is_inbounds(shape, image)
-        _draw!(image, shape, color) do image, i_center, j_center, i, j_inner, j_outer, color
-             _draw!(image, EvenSymmetricLines8(Point(i_center, j_center), i, j_inner, j_outer), color)
-        end
+        _draw!(put_pixel_unchecked!, image, shape, color)
     else
-        _draw!(image, shape, color) do image, i_center, j_center, i, j_inner, j_outer, color
-             draw!(image, EvenSymmetricLines8(Point(i_center, j_center), i, j_inner, j_outer), color)
-        end
+        _draw!(put_pixel!, image, shape, color)
     end
 
     return nothing
 end
 
-function _draw!(image::AbstractMatrix, shape::EvenThickCircle, color)
-    position = shape.position
-    diameter = shape.diameter
-
-    I = typeof(diameter)
-
-    i_position = position.i
-    j_position = position.j
-
-    radius = diameter ÷ convert(I, 2)
-    center = Point(i_position + radius, j_position + radius)
-
-    _draw!(image, shape, color) do image, _, _, i, j_inner, j_outer, color
-        _draw!(image, EvenSymmetricLines8(center, i, j_inner, j_outer), color)
-    end
-
-    return nothing
-end
+_draw!(image::AbstractMatrix, shape::EvenThickCircle, color) = _draw!(put_pixel_unchecked!, image, shape, color)
 
 function _draw!(f::Function, image::AbstractMatrix, shape::EvenThickCircle, color)
     position = shape.position
@@ -834,61 +795,10 @@ function _draw!(f::Function, image::AbstractMatrix, shape::EvenThickCircle, colo
 
     I = typeof(diameter)
 
-    i_position = position.i
-    j_position = position.j
+    center, radius = get_center_radius(shape)
 
-    radius = diameter ÷ convert(I, 2)
-
-    i_center = i_position + radius
-    j_center = j_position + radius
-    center = Point(i_center, j_center)
-
-    i_position_inner = i_position + thickness - one(I)
-    j_position_inner = j_position + thickness - one(I)
-
-    diameter_inner = diameter - convert(I, 2) * (thickness - one(I))
-    radius_outer = radius
-    radius_inner = diameter_inner ÷ convert(I, 2)
-
-    i_inner = zero(I)
-    j_inner = radius_inner
-
-    i_outer = zero(I)
-    j_outer = radius_outer
-
-    f(image, i_center, j_center, i_outer, j_inner, j_outer, color)
-
-    constant_inner = convert(I, 3) - convert(I, 2) * radius_inner * radius_inner
-    constant_outer = convert(I, 3) - convert(I, 2) * radius_outer * radius_outer
-
-    while j_inner >= i_inner
-        d_inner = convert(I, 2) * j_inner * j_inner + convert(I, 2) * i_inner * i_inner + convert(I, 4) * i_inner - convert(I, 2) * j_inner + constant_inner
-        d_outer = convert(I, 2) * j_outer * j_outer + convert(I, 2) * i_outer * i_outer + convert(I, 4) * i_outer - convert(I, 2) * j_outer + constant_outer
-
-        i_inner += one(I)
-        i_outer += one(I)
-
-        if d_inner > zero(I)
-            j_inner -= one(I)
-        end
-
-        if d_outer > zero(I)
-            j_outer -= one(I)
-        end
-
-        f(image, i_center, j_center, i_outer, j_inner, j_outer, color)
-    end
-
-    while j_outer >= i_outer
-        d_outer = convert(I, 2) * j_outer * j_outer + convert(I, 2) * i_outer * i_outer + convert(I, 4) * i_outer - convert(I, 2) * j_outer + constant_outer
-
-        i_outer += one(I)
-
-        if d_outer > zero(I)
-            j_outer -= one(I)
-        end
-
-        f(image, i_center, j_center, i_outer, j_inner, j_outer, color)
+    _draw!(image, ThickCircleOctant(center, radius, thickness), color) do image, i1, j1, i2, j2, color
+        _draw!(f, image, EvenSymmetricLines8(center, i1, i2, j1), color)
     end
 
     return nothing

--- a/src/circle.jl
+++ b/src/circle.jl
@@ -1,16 +1,11 @@
 abstract type AbstractCircle <: AbstractShape end
 
-struct EvenSymmetricPoints8{I <: Integer} <: AbstractShape
-    center::Point{I}
-    point::Point{I}
-end
-
 struct OddSymmetricPoints8{I <: Integer} <: AbstractShape
     center::Point{I}
     point::Point{I}
 end
 
-struct EvenSymmetricVerticalLines4{I <: Integer} <: AbstractShape
+struct EvenSymmetricPoints8{I <: Integer} <: AbstractShape
     center::Point{I}
     point::Point{I}
 end
@@ -20,11 +15,9 @@ struct OddSymmetricVerticalLines4{I <: Integer} <: AbstractShape
     point::Point{I}
 end
 
-struct EvenSymmetricLines8{I <: Integer} <: AbstractShape
+struct EvenSymmetricVerticalLines4{I <: Integer} <: AbstractShape
     center::Point{I}
-    i_inner::I
-    i_outer::I
-    j::I
+    point::Point{I}
 end
 
 struct OddSymmetricLines8{I <: Integer} <: AbstractShape
@@ -34,14 +27,16 @@ struct OddSymmetricLines8{I <: Integer} <: AbstractShape
     j::I
 end
 
+struct EvenSymmetricLines8{I <: Integer} <: AbstractShape
+    center::Point{I}
+    i_inner::I
+    i_outer::I
+    j::I
+end
+
 struct StandardCircleOctant{I <: Integer} <: AbstractShape
     center::Point{I}
     radius::I
-end
-
-struct Circle{I <: Integer} <: AbstractCircle
-    position::Point{I}
-    diameter::I
 end
 
 struct OddCircle{I <: Integer} <: AbstractCircle
@@ -54,7 +49,7 @@ struct EvenCircle{I <: Integer} <: AbstractCircle
     diameter::I
 end
 
-struct FilledCircle{I <: Integer} <: AbstractCircle
+struct Circle{I <: Integer} <: AbstractCircle
     position::Point{I}
     diameter::I
 end
@@ -69,10 +64,9 @@ struct EvenFilledCircle{I <: Integer} <: AbstractCircle
     diameter::I
 end
 
-struct ThickCircle{I <: Integer} <: AbstractCircle
+struct FilledCircle{I <: Integer} <: AbstractCircle
     position::Point{I}
     diameter::I
-    thickness::I
 end
 
 struct ThickCircleOctant{I <: Integer} <: AbstractShape
@@ -91,6 +85,44 @@ struct EvenThickCircle{I <: Integer} <: AbstractCircle
     position::Point{I}
     diameter::I
     thickness::I
+end
+
+struct ThickCircle{I <: Integer} <: AbstractCircle
+    position::Point{I}
+    diameter::I
+    thickness::I
+end
+
+#####
+##### OddSymmetricPoints8
+#####
+
+draw!(image::AbstractMatrix, shape::OddSymmetricPoints8, color) = _draw!(put_pixel!, image, shape, color)
+
+_draw!(image::AbstractMatrix, shape::OddSymmetricPoints8, color) = _draw!(put_pixel_unchecked!, image, shape, color)
+
+function _draw!(f::Function, image::AbstractMatrix, shape::OddSymmetricPoints8, color)
+    center = shape.center
+    point = shape.point
+
+    i_center = center.i
+    j_center = center.j
+    i = point.i
+    j = point.j
+
+    i_diff = i - i_center
+    j_diff = j - j_center
+
+    f(image, i_center - j_diff, j_center - i_diff, color)
+    f(image, i_center + j_diff, j_center - i_diff, color)
+    f(image, i_center - i_diff, j_center - j_diff, color)
+    f(image, i_center + i_diff, j_center - j_diff, color)
+    f(image, i_center - i_diff, j_center + j_diff, color)
+    f(image, i, j, color)
+    f(image, i_center - j_diff, j_center + i_diff, color)
+    f(image, i_center + j_diff, j_center + i_diff, color)
+
+    return nothing
 end
 
 #####
@@ -127,14 +159,14 @@ function _draw!(f::Function, image::AbstractMatrix, shape::EvenSymmetricPoints8,
 end
 
 #####
-##### OddSymmetricPoints8
+##### OddSymmetricVerticalLines4
 #####
 
-draw!(image::AbstractMatrix, shape::OddSymmetricPoints8, color) = _draw!(put_pixel!, image, shape, color)
+draw!(image::AbstractMatrix, shape::OddSymmetricVerticalLines4, color) = _draw!(put_pixel!, image, shape, color)
 
-_draw!(image::AbstractMatrix, shape::OddSymmetricPoints8, color) = _draw!(put_pixel_unchecked!, image, shape, color)
+_draw!(image::AbstractMatrix, shape::OddSymmetricVerticalLines4, color) = _draw!(put_pixel_unchecked!, image, shape, color)
 
-function _draw!(f::Function, image::AbstractMatrix, shape::OddSymmetricPoints8, color)
+function _draw!(f::Function, image::AbstractMatrix, shape::OddSymmetricVerticalLines4, color)
     center = shape.center
     point = shape.point
 
@@ -146,14 +178,10 @@ function _draw!(f::Function, image::AbstractMatrix, shape::OddSymmetricPoints8, 
     i_diff = i - i_center
     j_diff = j - j_center
 
-    f(image, i_center - j_diff, j_center - i_diff, color)
-    f(image, i_center + j_diff, j_center - i_diff, color)
-    f(image, i_center - i_diff, j_center - j_diff, color)
-    f(image, i_center + i_diff, j_center - j_diff, color)
-    f(image, i_center - i_diff, j_center + j_diff, color)
-    f(image, i, j, color)
-    f(image, i_center - j_diff, j_center + i_diff, color)
-    f(image, i_center + j_diff, j_center + i_diff, color)
+    _draw!(f, image, VerticalLine(i_center - j_diff, i_center + j_diff, j_center - i_diff), color)
+    _draw!(f, image, VerticalLine(i_center - i_diff, i_center + i_diff, j_center - j_diff), color)
+    _draw!(f, image, VerticalLine(i_center - i_diff, i_center + i_diff, j_center + j_diff), color)
+    _draw!(f, image, VerticalLine(i_center - j_diff, i_center + j_diff, j_center + i_diff), color)
 
     return nothing
 end
@@ -189,29 +217,34 @@ function _draw!(f::Function, image::AbstractMatrix, shape::EvenSymmetricVertical
 end
 
 #####
-##### OddSymmetricVerticalLines4
+##### OddSymmetricLines8
 #####
 
-draw!(image::AbstractMatrix, shape::OddSymmetricVerticalLines4, color) = _draw!(put_pixel!, image, shape, color)
+draw!(image::AbstractMatrix, shape::OddSymmetricLines8, color) = _draw!(put_pixel!, image, shape, color)
 
-_draw!(image::AbstractMatrix, shape::OddSymmetricVerticalLines4, color) = _draw!(put_pixel_unchecked!, image, shape, color)
+_draw!(image::AbstractMatrix, shape::OddSymmetricLines8, color) = _draw!(put_pixel_unchecked!, image, shape, color)
 
-function _draw!(f::Function, image::AbstractMatrix, shape::OddSymmetricVerticalLines4, color)
+function _draw!(f::Function, image::AbstractMatrix, shape::OddSymmetricLines8, color)
     center = shape.center
-    point = shape.point
+    i_inner = shape.i_inner
+    i_outer = shape.i_outer
+    j = shape.j
 
     i_center = center.i
     j_center = center.j
-    i = point.i
-    j = point.j
 
-    i_diff = i - i_center
-    j_diff = j - j_center
+    i_inner_relative = i_inner - i_center
+    i_outer_relative = i_outer - i_center
+    j_relative = j - j_center
 
-    _draw!(f, image, VerticalLine(i_center - j_diff, i_center + j_diff, j_center - i_diff), color)
-    _draw!(f, image, VerticalLine(i_center - i_diff, i_center + i_diff, j_center - j_diff), color)
-    _draw!(f, image, VerticalLine(i_center - i_diff, i_center + i_diff, j_center + j_diff), color)
-    _draw!(f, image, VerticalLine(i_center - j_diff, i_center + j_diff, j_center + i_diff), color)
+    _draw!(f, image, HorizontalLine(i_center - j_relative, j_center - i_outer_relative, j_center - i_inner_relative), color)
+    _draw!(f, image, HorizontalLine(i_center + j_relative, j_center - i_outer_relative, j_center - i_inner_relative), color)
+    _draw!(f, image, VerticalLine(i_center - i_outer_relative, i_center - i_inner_relative, j_center - j_relative), color)
+    _draw!(f, image, VerticalLine(i_center + i_inner_relative, i_center + i_outer_relative, j_center - j_relative), color)
+    _draw!(f, image, VerticalLine(i_center - i_outer_relative, i_center - i_inner_relative, j_center + j_relative), color)
+    _draw!(f, image, VerticalLine(i_center + i_inner_relative, i_center + i_outer_relative, j_center + j_relative), color)
+    _draw!(f, image, HorizontalLine(i_center - j_relative, j_center + i_inner_relative, j_center + i_outer_relative), color)
+    _draw!(f, image, HorizontalLine(i_center + j_relative, j_center + i_inner_relative, j_center + i_outer_relative), color)
 
     return nothing
 end
@@ -247,39 +280,6 @@ function _draw!(f::Function, image::AbstractMatrix, shape::EvenSymmetricLines8, 
     _draw!(f, image, VerticalLine(i_center + i_inner_relative - one(I), i_center + i_outer_relative - one(I), j_center + j_relative - one(I)), color)
     _draw!(f, image, HorizontalLine(i_center - j_relative, j_center + i_inner_relative - one(I), j_center + i_outer_relative - one(I)), color)
     _draw!(f, image, HorizontalLine(i_center + j_relative - one(I), j_center + i_inner_relative - one(I), j_center + i_outer_relative - one(I)), color)
-
-    return nothing
-end
-
-#####
-##### OddSymmetricLines8
-#####
-
-draw!(image::AbstractMatrix, shape::OddSymmetricLines8, color) = _draw!(put_pixel!, image, shape, color)
-
-_draw!(image::AbstractMatrix, shape::OddSymmetricLines8, color) = _draw!(put_pixel_unchecked!, image, shape, color)
-
-function _draw!(f::Function, image::AbstractMatrix, shape::OddSymmetricLines8, color)
-    center = shape.center
-    i_inner = shape.i_inner
-    i_outer = shape.i_outer
-    j = shape.j
-
-    i_center = center.i
-    j_center = center.j
-
-    i_inner_relative = i_inner - i_center
-    i_outer_relative = i_outer - i_center
-    j_relative = j - j_center
-
-    _draw!(f, image, HorizontalLine(i_center - j_relative, j_center - i_outer_relative, j_center - i_inner_relative), color)
-    _draw!(f, image, HorizontalLine(i_center + j_relative, j_center - i_outer_relative, j_center - i_inner_relative), color)
-    _draw!(f, image, VerticalLine(i_center - i_outer_relative, i_center - i_inner_relative, j_center - j_relative), color)
-    _draw!(f, image, VerticalLine(i_center + i_inner_relative, i_center + i_outer_relative, j_center - j_relative), color)
-    _draw!(f, image, VerticalLine(i_center - i_outer_relative, i_center - i_inner_relative, j_center + j_relative), color)
-    _draw!(f, image, VerticalLine(i_center + i_inner_relative, i_center + i_outer_relative, j_center + j_relative), color)
-    _draw!(f, image, HorizontalLine(i_center - j_relative, j_center + i_inner_relative, j_center + i_outer_relative), color)
-    _draw!(f, image, HorizontalLine(i_center + j_relative, j_center + i_inner_relative, j_center + i_outer_relative), color)
 
     return nothing
 end
@@ -351,36 +351,6 @@ function is_inbounds(shape::AbstractCircle, image::AbstractMatrix)
 end
 
 get_bounding_box(shape::AbstractCircle) = Rectangle(shape.position, shape.diameter, shape.diameter)
-
-#####
-##### Circle
-#####
-
-function draw!(image::AbstractMatrix, shape::Circle, color)
-    position = shape.position
-    diameter = shape.diameter
-
-    if iseven(diameter)
-        draw!(image, EvenCircle(position, diameter), color)
-    else
-        draw!(image, OddCircle(position, diameter), color)
-    end
-
-    return nothing
-end
-
-function _draw!(image::AbstractMatrix, shape::Circle, color)
-    position = shape.position
-    diameter = shape.diameter
-
-    if iseven(diameter)
-        _draw!(image, EvenCircle(position, diameter), color)
-    else
-        _draw!(image, OddCircle(position, diameter), color)
-    end
-
-    return nothing
-end
 
 #####
 ##### StandardCircleOctant
@@ -492,32 +462,30 @@ function _draw!(f::Function, image::AbstractMatrix, shape::EvenCircle, color)
 end
 
 #####
-##### FilledCircle
+##### Circle
 #####
 
-function draw!(image::AbstractMatrix, shape::FilledCircle, color)
+function draw!(image::AbstractMatrix, shape::Circle, color)
     position = shape.position
     diameter = shape.diameter
 
     if iseven(diameter)
-        draw!(image, EvenFilledCircle(position, diameter), color)
+        draw!(image, EvenCircle(position, diameter), color)
     else
-        draw!(image, OddFilledCircle(position, diameter), color)
+        draw!(image, OddCircle(position, diameter), color)
     end
 
     return nothing
 end
 
-_draw!(image::AbstractMatrix, shape::FilledCircle, color) = _draw!(put_pixel_unchecked!, image, shape, color)
-
-function _draw!(f::Function, image::AbstractMatrix, shape::FilledCircle, color)
+function _draw!(image::AbstractMatrix, shape::Circle, color)
     position = shape.position
     diameter = shape.diameter
 
     if iseven(diameter)
-        _draw!(f, image, EvenFilledCircle(position, diameter), color)
+        _draw!(image, EvenCircle(position, diameter), color)
     else
-        _draw!(f, image, OddFilledCircle(position, diameter), color)
+        _draw!(image, OddCircle(position, diameter), color)
     end
 
     return nothing
@@ -590,44 +558,32 @@ function _draw!(f::Function, image::AbstractMatrix, shape::EvenFilledCircle, col
 end
 
 #####
-##### ThickCircle
+##### FilledCircle
 #####
 
-function is_valid(shape::ThickCircle)
+function draw!(image::AbstractMatrix, shape::FilledCircle, color)
     position = shape.position
     diameter = shape.diameter
-    thickness = shape.thickness
 
     if iseven(diameter)
-        return is_valid(EvenThickCircle(position, diameter, thickness))
+        draw!(image, EvenFilledCircle(position, diameter), color)
     else
-        return is_valid(OddThickCircle(position, diameter, thickness))
-    end
-end
-
-function draw!(image::AbstractMatrix, shape::ThickCircle, color)
-    position = shape.position
-    diameter = shape.diameter
-    thickness = shape.thickness
-
-    if iseven(diameter)
-        draw!(image, EvenThickCircle(position, diameter, thickness), color)
-    else
-        draw!(image, OddThickCircle(position, diameter, thickness), color)
+        draw!(image, OddFilledCircle(position, diameter), color)
     end
 
     return nothing
 end
 
-function _draw!(image::AbstractMatrix, shape::ThickCircle, color)
+_draw!(image::AbstractMatrix, shape::FilledCircle, color) = _draw!(put_pixel_unchecked!, image, shape, color)
+
+function _draw!(f::Function, image::AbstractMatrix, shape::FilledCircle, color)
     position = shape.position
     diameter = shape.diameter
-    thickness = shape.thickness
 
     if iseven(diameter)
-        _draw!(image, EvenThickCircle(position, diameter, thickness), color)
+        _draw!(f, image, EvenFilledCircle(position, diameter), color)
     else
-        _draw!(image, OddThickCircle(position, diameter, thickness), color)
+        _draw!(f, image, OddFilledCircle(position, diameter), color)
     end
 
     return nothing
@@ -799,6 +755,50 @@ function _draw!(f::Function, image::AbstractMatrix, shape::EvenThickCircle, colo
 
     _draw!(image, ThickCircleOctant(center, radius, thickness), color) do image, i1, j1, i2, j2, color
         _draw!(f, image, EvenSymmetricLines8(center, i1, i2, j1), color)
+    end
+
+    return nothing
+end
+
+#####
+##### ThickCircle
+#####
+
+function is_valid(shape::ThickCircle)
+    position = shape.position
+    diameter = shape.diameter
+    thickness = shape.thickness
+
+    if iseven(diameter)
+        return is_valid(EvenThickCircle(position, diameter, thickness))
+    else
+        return is_valid(OddThickCircle(position, diameter, thickness))
+    end
+end
+
+function draw!(image::AbstractMatrix, shape::ThickCircle, color)
+    position = shape.position
+    diameter = shape.diameter
+    thickness = shape.thickness
+
+    if iseven(diameter)
+        draw!(image, EvenThickCircle(position, diameter, thickness), color)
+    else
+        draw!(image, OddThickCircle(position, diameter, thickness), color)
+    end
+
+    return nothing
+end
+
+function _draw!(image::AbstractMatrix, shape::ThickCircle, color)
+    position = shape.position
+    diameter = shape.diameter
+    thickness = shape.thickness
+
+    if iseven(diameter)
+        _draw!(image, EvenThickCircle(position, diameter, thickness), color)
+    else
+        _draw!(image, OddThickCircle(position, diameter, thickness), color)
     end
 
     return nothing

--- a/src/circle.jl
+++ b/src/circle.jl
@@ -147,25 +147,7 @@ end
 ##### EvenSymmetricVerticalLines4
 #####
 
-function draw!(image::AbstractMatrix, shape::EvenSymmetricVerticalLines4, color)
-    center = shape.center
-    point = shape.point
-
-    i_center = center.i
-    j_center = center.j
-    i = point.i
-    j = point.j
-
-    I = typeof(i_center)
-    one_value = one(I)
-
-    draw!(image, VerticalLine(i_center - i, i_center + i - one_value, j_center - j), color)
-    draw!(image, VerticalLine(i_center - j, i_center + j - one_value, j_center - i), color)
-    draw!(image, VerticalLine(i_center - j, i_center + j - one_value, j_center + i - one_value), color)
-    draw!(image, VerticalLine(i_center - i, i_center + i - one_value, j_center + j - one_value), color)
-
-    return nothing
-end
+draw!(image::AbstractMatrix, shape::EvenSymmetricVerticalLines4, color) = _draw!(put_pixel!, image, shape, color)
 
 _draw!(image::AbstractMatrix, shape::EvenSymmetricVerticalLines4, color) = _draw!(put_pixel_unchecked!, image, shape, color)
 
@@ -193,22 +175,7 @@ end
 ##### OddSymmetricVerticalLines4
 #####
 
-function draw!(image::AbstractMatrix, shape::OddSymmetricVerticalLines4, color)
-    center = shape.center
-    point = shape.point
-
-    i_center = center.i
-    j_center = center.j
-    i = point.i
-    j = point.j
-
-    draw!(image, VerticalLine(i_center - i, i_center + i, j_center - j), color)
-    draw!(image, VerticalLine(i_center - j, i_center + j, j_center - i), color)
-    draw!(image, VerticalLine(i_center - j, i_center + j, j_center + i), color)
-    draw!(image, VerticalLine(i_center - i, i_center + i, j_center + j), color)
-
-    return nothing
-end
+draw!(image::AbstractMatrix, shape::OddSymmetricVerticalLines4, color) = _draw!(put_pixel!, image, shape, color)
 
 _draw!(image::AbstractMatrix, shape::OddSymmetricVerticalLines4, color) = _draw!(put_pixel_unchecked!, image, shape, color)
 
@@ -233,29 +200,7 @@ end
 ##### EvenSymmetricLines8
 #####
 
-function draw!(image::AbstractMatrix, shape::EvenSymmetricLines8, color)
-    center = shape.center
-    i = shape.i
-    j_inner = shape.j_inner
-    j_outer = shape.j_outer
-
-    i_center = center.i
-    j_center = center.j
-
-    I = typeof(i_center)
-    one_value = one(I)
-
-    draw!(image, HorizontalLine(i_center - i, j_center - j_outer, j_center - j_inner), color)
-    draw!(image, HorizontalLine(i_center + i - one_value, j_center - j_outer, j_center - j_inner), color)
-    draw!(image, VerticalLine(i_center - j_outer, i_center - j_inner, j_center - i), color)
-    draw!(image, VerticalLine(i_center + j_inner - one_value, i_center + j_outer - one_value, j_center - i), color)
-    draw!(image, VerticalLine(i_center - j_outer, i_center - j_inner, j_center + i - one_value), color)
-    draw!(image, VerticalLine(i_center + j_inner - one_value, i_center + j_outer - one_value, j_center + i - one_value), color)
-    draw!(image, HorizontalLine(i_center - i, j_center + j_inner - one_value, j_center + j_outer - one_value), color)
-    draw!(image, HorizontalLine(i_center + i - one_value, j_center + j_inner - one_value, j_center + j_outer - one_value), color)
-
-    return nothing
-end
+draw!(image::AbstractMatrix, shape::EvenSymmetricLines8, color) = _draw!(put_pixel!, image, shape, color)
 
 _draw!(image::AbstractMatrix, shape::EvenSymmetricLines8, color) = _draw!(put_pixel_unchecked!, image, shape, color)
 
@@ -287,26 +232,7 @@ end
 ##### OddSymmetricLines8
 #####
 
-function draw!(image::AbstractMatrix, shape::OddSymmetricLines8, color)
-    center = shape.center
-    i = shape.i
-    j_inner = shape.j_inner
-    j_outer = shape.j_outer
-
-    i_center = center.i
-    j_center = center.j
-
-    draw!(image, HorizontalLine(i_center - i, j_center - j_outer, j_center - j_inner), color)
-    draw!(image, HorizontalLine(i_center + i, j_center - j_outer, j_center - j_inner), color)
-    draw!(image, VerticalLine(i_center - j_outer, i_center - j_inner, j_center - i), color)
-    draw!(image, VerticalLine(i_center + j_inner, i_center + j_outer, j_center - i), color)
-    draw!(image, VerticalLine(i_center - j_outer, i_center - j_inner, j_center + i), color)
-    draw!(image, VerticalLine(i_center + j_inner, i_center + j_outer, j_center + i), color)
-    draw!(image, HorizontalLine(i_center - i, j_center + j_inner, j_center + j_outer), color)
-    draw!(image, HorizontalLine(i_center + i, j_center + j_inner, j_center + j_outer), color)
-
-    return nothing
-end
+draw!(image::AbstractMatrix, shape::OddSymmetricLines8, color) = _draw!(put_pixel!, image, shape, color)
 
 _draw!(image::AbstractMatrix, shape::OddSymmetricLines8, color) = _draw!(put_pixel_unchecked!, image, shape, color)
 

--- a/src/line.jl
+++ b/src/line.jl
@@ -321,28 +321,18 @@ end
 function draw!(image::AbstractMatrix, shape::ThickLine, color)
     @assert is_valid(shape) "Cannot draw invalid shape $(shape)"
 
-    point1 = shape.point1
-    point2 = shape.point2
-    diameter = shape.diameter
-
-    I = typeof(diameter)
-
-    radius = diameter ÷ convert(I, 2)
-
     if is_inbounds(shape, image)
-        _draw!(image, Line(point1, point2), color) do image, i, j, color
-            _draw!(image, FilledCircle(Point(i - radius, j - radius), diameter), color)
-        end
+        _draw!(put_pixel_unchecked!, image, shape, color)
     else
-        _draw!(image, Line(point1, point2), color) do image, i, j, color
-            draw!(image, FilledCircle(Point(i - radius, j - radius), diameter), color)
-        end
+        _draw!(put_pixel!, image, shape, color)
     end
 
     return nothing
 end
 
-function _draw!(image::AbstractMatrix, shape::ThickLine, color)
+_draw!(image::AbstractMatrix, shape::ThickLine, color) = _draw!(put_pixel_unchecked!, image, shape, color)
+
+function _draw!(f::Function, image::AbstractMatrix, shape::ThickLine, color)
     point1 = shape.point1
     point2 = shape.point2
     diameter = shape.diameter
@@ -352,7 +342,7 @@ function _draw!(image::AbstractMatrix, shape::ThickLine, color)
     radius = diameter ÷ convert(I, 2)
 
     _draw!(image, Line(point1, point2), color) do image, i, j, color
-        _draw!(image, FilledCircle(Point(i - radius, j - radius), diameter), color)
+        _draw!(f, image, FilledCircle(Point(i - radius, j - radius), diameter), color)
     end
 
     return nothing

--- a/src/line.jl
+++ b/src/line.jl
@@ -77,8 +77,17 @@ function draw!(image::AbstractMatrix, shape::VerticalLine, color)
     return nothing
 end
 
-@inline function _draw!(image::AbstractMatrix, shape::VerticalLine, color)
-    @inbounds image[shape.i_min:shape.i_max, shape.j] .= color
+_draw!(image::AbstractMatrix, shape::VerticalLine, color) = _draw!(put_pixel_unchecked!, image, shape, color)
+
+function _draw!(f::Function, image::AbstractMatrix, shape::VerticalLine, color)
+    i_min = shape.i_min
+    i_max = shape.i_max
+    j = shape.j
+
+    for i in i_min:i_max
+        f(image, i, j, color)
+    end
+
     return nothing
 end
 
@@ -138,8 +147,17 @@ function draw!(image::AbstractMatrix, shape::HorizontalLine, color)
     return nothing
 end
 
-@inline function _draw!(image::AbstractMatrix, shape::HorizontalLine, color)
-    @inbounds image[shape.i, shape.j_min:shape.j_max] .= color
+_draw!(image::AbstractMatrix, shape::HorizontalLine, color) = _draw!(put_pixel_unchecked!, image, shape, color)
+
+function _draw!(f::Function, image::AbstractMatrix, shape::HorizontalLine, color)
+    i = shape.i
+    j_min = shape.j_min
+    j_max = shape.j_max
+
+    for j in j_min:j_max
+        f(image, i, j, color)
+    end
+
     return nothing
 end
 

--- a/src/point.jl
+++ b/src/point.jl
@@ -3,13 +3,12 @@ struct Point{I <: Integer} <: AbstractShape
     j::I
 end
 
-@inline function draw!(image::AbstractMatrix, shape::Point, color)
-    put_pixel!(image, shape.i, shape.j, color)
-    return nothing
-end
+draw!(image::AbstractMatrix, shape::Point, color) = _draw!(put_pixel!, image, shape, color)
 
-@inline function _draw!(image::AbstractMatrix, shape::Point, color)
-    put_pixel_unchecked!(image, shape.i, shape.j, color)
+_draw!(image::AbstractMatrix, shape::Point, color) = _draw!(put_pixel_unchecked!, image, shape, color)
+
+function _draw!(f::Function, image::AbstractMatrix, shape::Point, color)
+    f(image, shape.i, shape.j, color)
     return nothing
 end
 

--- a/src/text.jl
+++ b/src/text.jl
@@ -28,7 +28,9 @@ function draw!(image::AbstractMatrix, shape::TextLine, color)
     return nothing
 end
 
-function _draw!(image::AbstractMatrix, shape::TextLine, color)
+_draw!(image::AbstractMatrix, shape::TextLine, color) = _draw!(put_pixel_unchecked!, image, shape, color)
+
+function _draw!(f::Function, image::AbstractMatrix, shape::TextLine, color)
     position = shape.position
     text = shape.text
     font = shape.font
@@ -43,7 +45,7 @@ function _draw!(image::AbstractMatrix, shape::TextLine, color)
     char_position = position
 
     for char in text
-        _draw!(image, Character(char_position, char, font), color)
+        _draw!(f, image, Character(char_position, char, font), color)
         char_position = Point(char_position.i, char_position.j + width)
     end
 


### PR DESCRIPTION
1. Update `_draw!` to behave like an iterator and take a function as an argument like `put_pixel!`, or `put_pixel_undirected!` or any anonymous function. This significantly increases code reuse without sacrificing performance when things are type-stable.
1. Remove `inline` macros for drawing `Point` and `Background`.
1. Add shapes `CircleOctant` and `ThickCircleOctant` to iterate over the first octant (`i >= 0`, `j >=0`, `i >= j`) for drawing these circles. Accordingly modify `OddSymmetricPoints8`, `OddSymmetricVerticalLines4`, `OddSymmetricLines8`, and their corresponding `Even` counterparts.
1. Use explicit iteration for drawing `VerticalLine`, `HorizontalLine`, and `FilledRectangle`.
