### PR TITLE
add drawing optimization traits

### DIFF
--- a/src/background.jl
+++ b/src/background.jl
@@ -1,6 +1,6 @@
 struct Background <: AbstractShape end
 
-draw!(image::AbstractMatrix, shape::Background, color) = draw!(put_pixel_unchecked!, image, shape, color)
+get_drawing_optimization_style(::Background) = PUT_PIXEL_UNCHECKED
 
 function draw!(f::Function, image::AbstractMatrix, shape::Background, color)
     for j in axes(image, 2)

--- a/src/bitmap.jl
+++ b/src/bitmap.jl
@@ -29,15 +29,7 @@ function clip(shape::Bitmap, image::AbstractMatrix)
     return Bitmap(position, clipped_bitmap)
 end
 
-function draw!(image::AbstractMatrix, shape::Bitmap, color)
-    if is_outbounds(shape, image)
-        return nothing
-    end
-
-    draw!(put_pixel_unchecked!, image, clip(shape, image), color)
-
-    return nothing
-end
+get_drawing_optimization_style(::Bitmap) = CLIP
 
 function draw!(f::Function, image::AbstractMatrix, shape::Bitmap, color)
     position = shape.position

--- a/src/circle.jl
+++ b/src/circle.jl
@@ -73,6 +73,8 @@ get_i_max(shape::AbstractOctant) = shape.center.i + shape.radius
 get_j_min(shape::AbstractOctant) = shape.center.j
 get_j_max(shape::AbstractOctant) = shape.center.j + shape.radius
 
+get_drawing_optimization_style(::AbstractOctant) = CHECK_BOUNDS
+
 #####
 ##### CircleOctant
 #####
@@ -123,8 +125,18 @@ function draw!(image::AbstractMatrix, shape::ThickCircleOctant, color)
     radius = shape.radius
     thickness = shape.thickness
 
-    draw!(image, ThickCircleOctant(center, radius, thickness), color) do image, i1, j1, i2, j2, color
-        draw!(put_pixel!, image, VerticalLine(i1, i2, j1), color)
+    if is_outbounds(shape, image)
+        return nothing
+    end
+
+    if is_inbounds(shape, image)
+        draw!(image, ThickCircleOctant(center, radius, thickness), color) do image, i1, j1, i2, j2, color
+            draw!(put_pixel_unchecked!, image, VerticalLine(i1, i2, j1), color)
+        end
+    else
+        draw!(image, ThickCircleOctant(center, radius, thickness), color) do image, i1, j1, i2, j2, color
+            draw!(put_pixel!, image, VerticalLine(i1, i2, j1), color)
+        end
     end
 
     return nothing
@@ -216,6 +228,8 @@ get_i_max(shape::AbstractCircle) = shape.position.i + shape.diameter - one(shape
 
 get_j_min(shape::AbstractCircle) = shape.position.j
 get_j_max(shape::AbstractCircle) = shape.position.j + shape.diameter - one(shape.diameter)
+
+get_drawing_optimization_style(::AbstractCircle) = CHECK_BOUNDS
 
 #####
 ##### OddCircle

--- a/src/line.jl
+++ b/src/line.jl
@@ -37,17 +37,7 @@ get_j_max(shape::VerticalLine) = shape.j
 
 clip(shape::VerticalLine, image::AbstractMatrix) = VerticalLine(max(get_i_min(shape), get_i_min(image)), min(get_i_max(shape), get_i_max(image)), shape.j)
 
-function draw!(image::AbstractMatrix, shape::VerticalLine, color)
-    @assert is_valid(shape) "Cannot draw invalid shape $(shape)"
-
-    if is_outbounds(shape, image)
-        return nothing
-    end
-
-    draw!(put_pixel_unchecked!, image, clip(shape, image), color)
-
-    return nothing
-end
+get_drawing_optimization_style(::VerticalLine) = CLIP
 
 function draw!(f::Function, image::AbstractMatrix, shape::VerticalLine, color)
     @assert is_valid(shape) "Cannot draw invalid shape $(shape)"
@@ -77,17 +67,7 @@ get_j_max(shape::HorizontalLine) = shape.j_max
 
 clip(shape::HorizontalLine, image::AbstractMatrix) = HorizontalLine(shape.i, max(get_j_min(shape), get_j_min(image)), min(get_j_max(shape), get_j_max(image)))
 
-function draw!(image::AbstractMatrix, shape::HorizontalLine, color)
-    @assert is_valid(shape) "Cannot draw invalid shape $(shape)"
-
-    if is_outbounds(shape, image)
-        return nothing
-    end
-
-    draw!(put_pixel_unchecked!, image, clip(shape, image), color)
-
-    return nothing
-end
+get_drawing_optimization_style(::HorizontalLine) = CLIP
 
 function draw!(f::Function, image::AbstractMatrix, shape::HorizontalLine, color)
     @assert is_valid(shape) "Cannot draw invalid shape $(shape)"
@@ -114,6 +94,8 @@ get_i_extrema(shape::Line) = minmax(shape.point1.i, shape.point2.i)
 get_j_min(shape::Line) = min(shape.point1.j, shape.point2.j)
 get_j_max(shape::Line) = max(shape.point1.j, shape.point2.j)
 get_j_extrema(shape::Line) = minmax(shape.point1.j, shape.point2.j)
+
+get_drawing_optimization_style(::Line) = CHECK_BOUNDS
 
 function draw!(f::Function, image::AbstractMatrix, shape::Line, color)
     point1 = shape.point1
@@ -198,6 +180,8 @@ function get_j_max(shape::ThickLine)
         return j_max + radius
     end
 end
+
+get_drawing_optimization_style(::ThickLine) = CHECK_BOUNDS
 
 function draw!(f::Function, image::AbstractMatrix, shape::ThickLine, color)
     @assert is_valid(shape) "Cannot draw invalid shape $(shape)"

--- a/src/point.jl
+++ b/src/point.jl
@@ -3,7 +3,7 @@ struct Point{I <: Integer} <: AbstractShape
     j::I
 end
 
-draw!(image::AbstractMatrix, shape::Point, color) = draw!(put_pixel!, image, shape, color)
+get_drawing_optimization_style(::Point) = PUT_PIXEL
 
 function draw!(f::Function, image::AbstractMatrix, shape::Point, color)
     f(image, shape.i, shape.j, color)

--- a/src/rectangle.jl
+++ b/src/rectangle.jl
@@ -31,6 +31,8 @@ get_i_max(shape::AbstractRectangle) = shape.position.i + shape.height - one(shap
 get_j_min(shape::AbstractRectangle) = shape.position.j
 get_j_max(shape::AbstractRectangle) = shape.position.j + shape.width - one(shape.width)
 
+get_drawing_optimization_style(::AbstractRectangle) = CHECK_BOUNDS
+
 #####
 ##### Rectangle
 #####
@@ -76,17 +78,7 @@ function clip(shape::FilledRectangle, image::AbstractMatrix)
     return FilledRectangle(Point(i_min, j_min), i_max - i_min + one(I), j_max - j_min + one(I))
 end
 
-function draw!(image::AbstractMatrix, shape::FilledRectangle, color)
-    @assert is_valid(shape) "Cannot draw invalid shape $(shape)"
-
-    if is_outbounds(shape, image)
-        return nothing
-    end
-
-    draw!(put_pixel_unchecked!, image, clip(shape, image), color)
-
-    return nothing
-end
+get_drawing_optimization_style(::FilledRectangle) = CLIP
 
 function draw!(f::Function, image::AbstractMatrix, shape::FilledRectangle, color)
     @assert is_valid(shape) "Cannot draw invalid shape $(shape)"

--- a/src/text.jl
+++ b/src/text.jl
@@ -6,27 +6,7 @@ end
 
 is_valid(shape::TextLine) = all(x -> has_char(shape.font, x), shape.text)
 
-function draw!(image::AbstractMatrix, shape::TextLine, color)
-    @assert is_valid(shape) "Cannot draw invalid shape $(shape)"
-
-    position = shape.position
-    text = shape.text
-    font = shape.font
-
-    bitmap = font.bitmap
-
-    height = size(bitmap, 1)
-    width = size(bitmap, 2)
-
-    char_position = position
-
-    for char in text
-        draw!(image, Character(char_position, char, font), color)
-        char_position = Point(char_position.i, char_position.j + width)
-    end
-
-    return nothing
-end
+get_drawing_optimization_style(::TextLine) = PUT_PIXEL
 
 function draw!(f::Function, image::AbstractMatrix, shape::TextLine, color)
     @assert is_valid(shape) "Cannot draw invalid shape $(shape)"


### PR DESCRIPTION
1. Add 4 drawing optimization traits in increasing order of optimization `PutPixel`, `CheckBounds`, `Clip`, `PutPixelUnchecked`, and corresponding generic `draw!` methods.
2. Remove `draw!` method without argument `f` for those shapes where the above traits apply directly.