### PR TITLE
reverse arg order for is_inbounds, is_outbounds, clip

### DIFF
--- a/src/abstract_shape.jl
+++ b/src/abstract_shape.jl
@@ -28,7 +28,7 @@ function is_outbounds(image::AbstractMatrix, shape::AbstractShape)
     return i_max_shape < i_min_image || i_min_shape > i_max_image || j_max_shape < j_min_image || j_min_shape > j_max_image
 end
 
-function is_inbounds(shape::AbstractShape, image::AbstractMatrix)
+function is_inbounds(image::AbstractMatrix, shape::AbstractShape)
     i_min_shape, i_max_shape = get_i_extrema(shape)
     i_min_image, i_max_image = get_i_extrema(image)
 
@@ -88,7 +88,7 @@ function draw!(::CheckBounds, image::AbstractMatrix, shape::AbstractShape, color
         return nothing
     end
 
-    if is_inbounds(shape, image)
+    if is_inbounds(image, shape)
         draw!(put_pixel_unchecked!, image, shape, color)
     else
         draw!(put_pixel!, image, shape, color)

--- a/src/abstract_shape.jl
+++ b/src/abstract_shape.jl
@@ -18,7 +18,7 @@ get_j_min(image::AbstractMatrix) = firstindex(image, 2)
 get_j_max(image::AbstractMatrix) = lastindex(image, 2)
 get_j_extrema(x) = (get_j_min(x), get_j_max(x))
 
-function is_outbounds(shape::AbstractShape, image::AbstractMatrix)
+function is_outbounds(image::AbstractMatrix, shape::AbstractShape)
     i_min_shape, i_max_shape = get_i_extrema(shape)
     i_min_image, i_max_image = get_i_extrema(image)
 
@@ -84,7 +84,7 @@ const CHECK_BOUNDS = CheckBounds()
 function draw!(::CheckBounds, image::AbstractMatrix, shape::AbstractShape, color)
     @assert is_valid(shape) "Cannot draw invalid shape $(shape)"
 
-    if is_outbounds(shape, image)
+    if is_outbounds(image, shape)
         return nothing
     end
 
@@ -107,7 +107,7 @@ const CLIP = Clip()
 function draw!(::Clip, image::AbstractMatrix, shape::AbstractShape, color)
     @assert is_valid(shape) "Cannot draw invalid shape $(shape)"
 
-    if is_outbounds(shape, image)
+    if is_outbounds(image, shape)
         return nothing
     end
 

--- a/src/abstract_shape.jl
+++ b/src/abstract_shape.jl
@@ -111,7 +111,7 @@ function draw!(::Clip, image::AbstractMatrix, shape::AbstractShape, color)
         return nothing
     end
 
-    draw!(put_pixel_unchecked!, image, clip(shape, image), color)
+    draw!(put_pixel_unchecked!, image, clip(image, shape), color)
 
     return nothing
 end

--- a/src/bitmap.jl
+++ b/src/bitmap.jl
@@ -9,7 +9,7 @@ get_i_max(shape::Bitmap) = shape.position.i + size(shape.bitmap, 1) - one(shape.
 get_j_min(shape::Bitmap) = shape.position.j
 get_j_max(shape::Bitmap) = shape.position.j + size(shape.bitmap, 2) - one(shape.position.j)
 
-function clip(shape::Bitmap, image::AbstractMatrix)
+function clip(image::AbstractMatrix, shape::Bitmap)
     position = shape.position
     bitmap = shape.bitmap
 

--- a/src/character.jl
+++ b/src/character.jl
@@ -40,7 +40,7 @@ function draw!(image::AbstractMatrix, shape::Character{I, C, Terminus_32_16} whe
     char = shape.char
     font = shape.font
 
-    if is_outbounds(shape, image)
+    if is_outbounds(image, shape)
         return nothing
     end
 

--- a/src/character.jl
+++ b/src/character.jl
@@ -48,7 +48,7 @@ function draw!(image::AbstractMatrix, shape::Character{I, C, Terminus_32_16} whe
         return nothing
     else
         bitmap_shape = Bitmap(position, get_bitmap(font, char))
-        draw!(put_pixel_unchecked!, image, clip(bitmap_shape, image), color)
+        draw!(put_pixel_unchecked!, image, clip(image, bitmap_shape), color)
     end
 
     return nothing

--- a/src/circle.jl
+++ b/src/circle.jl
@@ -125,7 +125,7 @@ function draw!(image::AbstractMatrix, shape::ThickCircleOctant, color)
     radius = shape.radius
     thickness = shape.thickness
 
-    if is_outbounds(shape, image)
+    if is_outbounds(image, shape)
         return nothing
     end
 

--- a/src/circle.jl
+++ b/src/circle.jl
@@ -129,7 +129,7 @@ function draw!(image::AbstractMatrix, shape::ThickCircleOctant, color)
         return nothing
     end
 
-    if is_inbounds(shape, image)
+    if is_inbounds(image, shape)
         draw!(image, ThickCircleOctant(center, radius, thickness), color) do image, i1, j1, i2, j2, color
             draw!(put_pixel_unchecked!, image, VerticalLine(i1, i2, j1), color)
         end

--- a/src/line.jl
+++ b/src/line.jl
@@ -35,7 +35,7 @@ get_i_max(shape::VerticalLine) = shape.i_max
 get_j_min(shape::VerticalLine) = shape.j
 get_j_max(shape::VerticalLine) = shape.j
 
-clip(shape::VerticalLine, image::AbstractMatrix) = VerticalLine(max(get_i_min(shape), get_i_min(image)), min(get_i_max(shape), get_i_max(image)), shape.j)
+clip(image::AbstractMatrix, shape::VerticalLine) = VerticalLine(max(get_i_min(shape), get_i_min(image)), min(get_i_max(shape), get_i_max(image)), shape.j)
 
 get_drawing_optimization_style(::VerticalLine) = CLIP
 
@@ -65,7 +65,7 @@ get_i_max(shape::HorizontalLine) = shape.i
 get_j_min(shape::HorizontalLine) = shape.j_min
 get_j_max(shape::HorizontalLine) = shape.j_max
 
-clip(shape::HorizontalLine, image::AbstractMatrix) = HorizontalLine(shape.i, max(get_j_min(shape), get_j_min(image)), min(get_j_max(shape), get_j_max(image)))
+clip(image::AbstractMatrix, shape::HorizontalLine) = HorizontalLine(shape.i, max(get_j_min(shape), get_j_min(image)), min(get_j_max(shape), get_j_max(image)))
 
 get_drawing_optimization_style(::HorizontalLine) = CLIP
 

--- a/src/rectangle.jl
+++ b/src/rectangle.jl
@@ -55,7 +55,7 @@ end
 ##### FilledRectangle
 #####
 
-function clip(shape::FilledRectangle, image::AbstractMatrix)
+function clip(image::AbstractMatrix, shape::FilledRectangle)
     i_min_shape, i_max_shape = get_i_extrema(shape)
     i_min_image, i_max_image = get_i_extrema(image)
 


### PR DESCRIPTION
Reverse arg order for `is_inbounds`, `is_outbounds`, `clip`. Make it of the form `f(image, shape)` instead of `f(shape, image)`