### PR TITLE
fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ For details on what exact shapes are drawn while generating these benchmarks, se
     struct ThickLine{I <: Integer} <: AbstractLine
         point1::Point{I}
         point2::Point{I}
-        diameter::I
+        thickness::I
     end
     ```
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ For details on what exact shapes are drawn while generating these benchmarks, se
     end
     ```
 
-    <img src="https://user-images.githubusercontent.com/32610387/147943690-a2e54b48-9d76-4b17-a983-7d0c662f99a8.png">
+    <img src="https://user-images.githubusercontent.com/32610387/148082257-79ded105-a737-4286-8d58-a5c821a41f14.png">
 
 1. ### `Circle`
 


### PR DESCRIPTION
1. Rename `diameter` to `thickness
2. Update screenshot for `ThickLine`

![thick_line](https://user-images.githubusercontent.com/32610387/148082257-79ded105-a737-4286-8d58-a5c821a41f14.png)
