### PR TITLE
update drawing of non-ascii and non-printable characters

### DIFF
--- a/src/text.jl
+++ b/src/text.jl
@@ -4,13 +4,9 @@ struct TextLine{I, S, F <: AbstractFont} <: AbstractShape
     font::F
 end
 
-is_valid(shape::TextLine) = all(x -> has_char(shape.font, x), shape.text)
-
 get_drawing_optimization_style(::TextLine) = PUT_PIXEL
 
 function draw!(f::F, image::AbstractMatrix, shape::TextLine, color) where {F <: Function}
-    @assert is_valid(shape) "Cannot draw invalid shape $(shape)"
-
     position = shape.position
     text = shape.text
     font = shape.font
@@ -24,7 +20,9 @@ function draw!(f::F, image::AbstractMatrix, shape::TextLine, color) where {F <: 
 
     for char in text
         draw!(f, image, Character(char_position, char, font), color)
-        char_position = Point(char_position.i, char_position.j + width)
+        if isprint(char)
+            char_position = Point(char_position.i, char_position.j + width)
+        end
     end
 
     return nothing


### PR DESCRIPTION
Fixes #127 

Non-printable characters will draw nothing and not advance cursor position in the text.

Non-ascii printable characters will be displayed like a full block character.