### PR TITLE
add is_valid, get_i_min, get_i_max, get_j_min, get_j_max to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,15 @@ SD.visualize(image)
 
 ### API
 
-This package does not export any names. The `draw!` function, along with all the types in [List of shapes](#list-of-shapes) can be considered as a part of the API. Everything else should be considered internal for now.
+This package does not export any names. All the types in [List of shapes](#list-of-shapes), along with the following functions can be considered as a part of the API:
+1. `draw!`
+1. `is_valid`
+1. `get_i_min`
+1. `get_i_max`
+1. `get_j_min`
+1. `get_j_max`
+
+Everything else should be considered internal for now.
 
 ### `draw!`
 

--- a/src/background.jl
+++ b/src/background.jl
@@ -2,6 +2,12 @@ struct Background <: AbstractShape end
 
 get_drawing_optimization_style(::Background) = PUT_PIXEL_INBOUNDS
 
+get_i_min(shape::Background) = error("i_min for $(shape) depends upon the type of image. Cannot determine it solely based on the shape")
+get_i_max(shape::Background) = error("i_max for $(shape) depends upon the type of image. Cannot determine it solely based on the shape")
+
+get_j_min(shape::Background) = error("j_min for $(shape) depends upon the type of image. Cannot determine it solely based on the shape")
+get_j_max(shape::Background) = error("j_max for $(shape) depends upon the type of image. Cannot determine it solely based on the shape")
+
 function draw!(f::F, image::AbstractMatrix, shape::Background, color) where {F <: Function}
     for j in axes(image, 2)
         for i in axes(image, 1)

--- a/src/bitmap.jl
+++ b/src/bitmap.jl
@@ -4,14 +4,18 @@ struct Bitmap{I <: Integer, B <: AbstractMatrix{Bool}} <: AbstractShape
 end
 
 get_i_min(shape::Bitmap) = shape.position.i
-get_i_max(shape::Bitmap) = shape.position.i + size(shape.bitmap, 1) - one(shape.position.i)
+get_i_max(shape::Bitmap) = isempty(shape.bitmap) ? shape.position.i : shape.position.i + size(shape.bitmap, 1) - one(shape.position.i)
 
 get_j_min(shape::Bitmap) = shape.position.j
-get_j_max(shape::Bitmap) = shape.position.j + size(shape.bitmap, 2) - one(shape.position.j)
+get_j_max(shape::Bitmap) = isempty(shape.bitmap) ? shape.position.j : shape.position.j + size(shape.bitmap, 2) - one(shape.position.j)
 
 function clip(image::AbstractMatrix, shape::Bitmap)
     position = shape.position
     bitmap = shape.bitmap
+
+    if isempty(bitmap)
+        return Bitmap(position, bitmap)
+    end
 
     i_min_shape, i_max_shape = get_i_extrema(shape)
     i_min_image, i_max_image = get_i_extrema(image)
@@ -34,6 +38,10 @@ get_drawing_optimization_style(::Bitmap) = CLIP
 function draw!(f::F, image::AbstractMatrix, shape::Bitmap, color) where {F <: Function}
     position = shape.position
     bitmap = shape.bitmap
+
+    if isempty(bitmap)
+        return nothing
+    end
 
     i_position = position.i
     j_position = position.j

--- a/src/character.jl
+++ b/src/character.jl
@@ -36,10 +36,10 @@ function get_bitmap(font::AbstractASCIIFont, char::Char)
 end
 
 get_i_min(shape::Character) = shape.position.i
-get_i_max(shape::Character) = shape.position.i + size(shape.font.bitmap, 1) - one(shape.position.i)
+get_i_max(shape::Character) = isprint(shape.char) ? shape.position.i + get_height(shape.font) - one(shape.position.i) : shape.position.i
 
 get_j_min(shape::Character) = shape.position.j
-get_j_max(shape::Character) = shape.position.j + size(shape.font.bitmap, 2) - one(shape.position.j)
+get_j_max(shape::Character) = isprint(shape.char) ? shape.position.j + get_width(shape.font) - one(shape.position.j) : shape.position.j
 
 function draw!(image::AbstractMatrix, shape::Character{I, C, <:AbstractASCIIFont} where {I, C}, color)
     position = shape.position

--- a/src/line.jl
+++ b/src/line.jl
@@ -143,7 +143,7 @@ end
 
 is_valid(shape::ThickLine) = shape.thickness > zero(shape.thickness)
 
-get_i_min(shape::ThickLine) = min(shape.point1.i, shape.point2.i) - shape.thickness ÷ 2
+get_i_min(shape::ThickLine) = min(shape.point1.i, shape.point2.i) - shape.thickness ÷ convert(typeof(shape.thickness), 2)
 
 function get_i_max(shape::ThickLine)
     point1 = shape.point1
@@ -156,12 +156,12 @@ function get_i_max(shape::ThickLine)
 
     i_max = max(point1.j, point2.j)
 
-    half_thickness = thickness ÷ 2
+    half_thickness = thickness ÷ convert(typeof(thickness), 2)
 
     return i_max - half_thickness + thickness - one(I)
 end
 
-get_j_min(shape::ThickLine) = min(shape.point1.j, shape.point2.j) - shape.thickness ÷ 2
+get_j_min(shape::ThickLine) = min(shape.point1.j, shape.point2.j) - shape.thickness ÷ convert(typeof(shape.thickness), 2)
 
 function get_j_max(shape::ThickLine)
     point1 = shape.point1
@@ -172,7 +172,7 @@ function get_j_max(shape::ThickLine)
 
     j_max = max(point1.j, point2.j)
 
-    half_thickness = thickness ÷ 2
+    half_thickness = thickness ÷ convert(typeof(thickness), 2)
 
     return j_max - half_thickness + thickness - one(I)
 end
@@ -193,7 +193,7 @@ function draw!(f::F, image::AbstractMatrix, shape::ThickLine, color) where {F <:
     i2 = point2.i
     j2 = point2.j
 
-    half_thickness = thickness ÷ 2
+    half_thickness = thickness ÷ convert(typeof(thickness), 2)
 
     draw!(image, Line(point1, point2), color) do image, i, j, color
         draw!(f, image, FilledRectangle(Point(i - half_thickness, j - half_thickness), thickness, thickness), color)

--- a/src/line.jl
+++ b/src/line.jl
@@ -150,11 +150,11 @@ function get_i_max(shape::ThickLine)
     point2 = shape.point2
     thickness = shape.thickness
 
-    i_max = max(point1.i, point2.i)
-
     I = typeof(thickness)
 
-    half_thickness = thickness ÷ convert(typeof(thickness), 2)
+    i_max = max(point1.i, point2.i)
+
+    half_thickness = thickness ÷ convert(I, 2)
 
     return i_max - half_thickness + thickness - one(I)
 end
@@ -170,7 +170,7 @@ function get_j_max(shape::ThickLine)
 
     j_max = max(point1.j, point2.j)
 
-    half_thickness = thickness ÷ convert(typeof(thickness), 2)
+    half_thickness = thickness ÷ convert(I, 2)
 
     return j_max - half_thickness + thickness - one(I)
 end
@@ -191,7 +191,7 @@ function draw!(f::F, image::AbstractMatrix, shape::ThickLine, color) where {F <:
     i2 = point2.i
     j2 = point2.j
 
-    half_thickness = thickness ÷ convert(typeof(thickness), 2)
+    half_thickness = thickness ÷ convert(I, 2)
 
     draw!(image, Line(point1, point2), color) do image, i, j, color
         draw!(f, image, FilledRectangle(Point(i - half_thickness, j - half_thickness), thickness, thickness), color)

--- a/src/line.jl
+++ b/src/line.jl
@@ -154,8 +154,6 @@ function get_i_max(shape::ThickLine)
 
     I = typeof(thickness)
 
-    i_max = max(point1.j, point2.j)
-
     half_thickness = thickness ÷ convert(typeof(thickness), 2)
 
     return i_max - half_thickness + thickness - one(I)

--- a/src/text.jl
+++ b/src/text.jl
@@ -6,6 +6,42 @@ end
 
 get_drawing_optimization_style(::TextLine) = PUT_PIXEL
 
+function get_num_printable(shape::TextLine)
+    num_printable = 0
+
+    for char in shape.text
+        if isprint(char)
+            num_printable += 1
+        end
+    end
+
+    return num_printable
+end
+
+get_i_min(shape::TextLine) = shape.position.i
+
+function get_i_max(shape::TextLine)
+    num_printable = get_num_printable(shape)
+
+    if num_printable > zero(num_printable)
+        return shape.position.i + get_height(shape.font) - one(shape.position.i)
+    else
+        return shape.position.i
+    end
+end
+
+get_j_min(shape::TextLine) = shape.position.j
+
+function get_j_max(shape::TextLine)
+    num_printable = get_num_printable(shape)
+
+    if num_printable > zero(num_printable)
+        return shape.position.j + num_printable * get_width(shape.font) - one(shape.position.j)
+    else
+        return shape.position.j
+    end
+end
+
 function draw!(f::F, image::AbstractMatrix, shape::TextLine, color) where {F <: Function}
     position = shape.position
     text = shape.text

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.Point(16, 16)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 16
+        Test.@test SD.get_i_max(shape) == 16
+        Test.@test SD.get_j_min(shape) == 16
+        Test.@test SD.get_j_max(shape) == 16
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -49,6 +54,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.Point(100 + 16, 100 + 16)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 100 + 16
+        Test.@test SD.get_i_max(shape) == 100 + 16
+        Test.@test SD.get_j_min(shape) == 100 + 16
+        Test.@test SD.get_j_max(shape) == 100 + 16
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == falses(height, width)
@@ -59,6 +69,7 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.Background()
+        Test.@test SD.is_valid(shape)
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -102,6 +113,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.VerticalLine(9, 24, 16)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 9
+        Test.@test SD.get_i_max(shape) == 24
+        Test.@test SD.get_j_min(shape) == 16
+        Test.@test SD.get_j_max(shape) == 16
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -143,6 +159,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.VerticalLine(16, 16, 16)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 16
+        Test.@test SD.get_i_max(shape) == 16
+        Test.@test SD.get_j_min(shape) == 16
+        Test.@test SD.get_j_max(shape) == 16
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -184,6 +205,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.VerticalLine(-1, 34, 16)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == -1
+        Test.@test SD.get_i_max(shape) == 34
+        Test.@test SD.get_j_min(shape) == 16
+        Test.@test SD.get_j_max(shape) == 16
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -225,6 +251,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.VerticalLine(100 + 9, 100 + 24, 100 + 16)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 100 + 9
+        Test.@test SD.get_i_max(shape) == 100 + 24
+        Test.@test SD.get_j_min(shape) == 100 + 16
+        Test.@test SD.get_j_max(shape) == 100 + 16
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == falses(height, width)
@@ -235,6 +266,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.HorizontalLine(16, 9, 24)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 16
+        Test.@test SD.get_i_max(shape) == 16
+        Test.@test SD.get_j_min(shape) == 9
+        Test.@test SD.get_j_max(shape) == 24
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -276,6 +312,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.HorizontalLine(16, 16, 16)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 16
+        Test.@test SD.get_i_max(shape) == 16
+        Test.@test SD.get_j_min(shape) == 16
+        Test.@test SD.get_j_max(shape) == 16
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -317,6 +358,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.HorizontalLine(16, -1, 34)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 16
+        Test.@test SD.get_i_max(shape) == 16
+        Test.@test SD.get_j_min(shape) == -1
+        Test.@test SD.get_j_max(shape) == 34
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -358,6 +404,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.HorizontalLine(100 + 16, 100 + 9, 100 + 24)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 100 + 16
+        Test.@test SD.get_i_max(shape) == 100 + 16
+        Test.@test SD.get_j_min(shape) == 100 + 9
+        Test.@test SD.get_j_max(shape) == 100 + 24
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == falses(height, width)
@@ -368,6 +419,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.Line(SD.Point(9, 5), SD.Point(24, 28))
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 9
+        Test.@test SD.get_i_max(shape) == 24
+        Test.@test SD.get_j_min(shape) == 5
+        Test.@test SD.get_j_max(shape) == 28
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -409,6 +465,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.Line(SD.Point(16, 16), SD.Point(16, 16))
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 16
+        Test.@test SD.get_i_max(shape) == 16
+        Test.@test SD.get_j_min(shape) == 16
+        Test.@test SD.get_j_max(shape) == 16
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -450,6 +511,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.Line(SD.Point(-1, -1), SD.Point(34, 34))
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == -1
+        Test.@test SD.get_i_max(shape) == 34
+        Test.@test SD.get_j_min(shape) == -1
+        Test.@test SD.get_j_max(shape) == 34
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -491,6 +557,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.Line(SD.Point(100 + 9, 100 + 5), SD.Point(100 + 24, 100 + 28))
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 100 + 9
+        Test.@test SD.get_i_max(shape) == 100 + 24
+        Test.@test SD.get_j_min(shape) == 100 + 5
+        Test.@test SD.get_j_max(shape) == 100 + 28
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == falses(height, width)
@@ -501,6 +572,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.ThickLine(SD.Point(9, 5), SD.Point(24, 28), 5)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 9 - 5 ÷ 2
+        Test.@test SD.get_i_max(shape) == 24 + 5 ÷ 2
+        Test.@test SD.get_j_min(shape) == 5 - 5 ÷ 2
+        Test.@test SD.get_j_max(shape) == 28 + 5 ÷ 2
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -542,6 +618,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.ThickLine(SD.Point(16, 16), SD.Point(16, 16), 1)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 16
+        Test.@test SD.get_i_max(shape) == 16
+        Test.@test SD.get_j_min(shape) == 16
+        Test.@test SD.get_j_max(shape) == 16
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -583,6 +664,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.ThickLine(SD.Point(9 + 10, 5 + 10), SD.Point(24 + 10, 28 + 10), 5)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 10 + 9 - 5 ÷ 2
+        Test.@test SD.get_i_max(shape) == 10 + 24 + 5 ÷ 2
+        Test.@test SD.get_j_min(shape) == 10 + 5 - 5 ÷ 2
+        Test.@test SD.get_j_max(shape) == 10 + 28 + 5 ÷ 2
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -623,7 +709,12 @@ Test.@testset "SimpleDraw.jl" begin
         height = 32
         width = 32
         image = falses(height, width)
-        shape = SD.ThickLine(SD.Point(100 + 9, 100 + 5), SD.Point(100 + 24, 100 + 28), 7)
+        shape = SD.ThickLine(SD.Point(100 + 9, 100 + 5), SD.Point(100 + 24, 100 + 28), 6)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 100 + 9 - 6 ÷ 2
+        Test.@test SD.get_i_max(shape) == 100 + 24 + 6 ÷ 2 - 1
+        Test.@test SD.get_j_min(shape) == 100 + 5 - 6 ÷ 2
+        Test.@test SD.get_j_max(shape) == 100 + 28 + 6 ÷ 2 - 1
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == falses(height, width)
@@ -1698,6 +1789,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.Circle(SD.Point(2, 2), 29)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 2
+        Test.@test SD.get_i_max(shape) == 30
+        Test.@test SD.get_j_min(shape) == 2
+        Test.@test SD.get_j_max(shape) == 30
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -1739,6 +1835,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.Circle(SD.Point(1, 1), 1)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 1
+        Test.@test SD.get_i_max(shape) == 1
+        Test.@test SD.get_j_min(shape) == 1
+        Test.@test SD.get_j_max(shape) == 1
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -1780,6 +1881,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.Circle(SD.Point(10, 10), 29)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 10
+        Test.@test SD.get_i_max(shape) == 38
+        Test.@test SD.get_j_min(shape) == 10
+        Test.@test SD.get_j_max(shape) == 38
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -1821,6 +1927,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.Circle(SD.Point(100 + 2, 100 + 2), 29)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 100 + 2
+        Test.@test SD.get_i_max(shape) == 100 + 30
+        Test.@test SD.get_j_min(shape) == 100 + 2
+        Test.@test SD.get_j_max(shape) == 100 + 30
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == falses(height, width)
@@ -1831,6 +1942,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.Circle(SD.Point(2, 2), 30)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 2
+        Test.@test SD.get_i_max(shape) == 31
+        Test.@test SD.get_j_min(shape) == 2
+        Test.@test SD.get_j_max(shape) == 31
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -1872,6 +1988,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.Circle(SD.Point(1, 1), 2)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 1
+        Test.@test SD.get_i_max(shape) == 2
+        Test.@test SD.get_j_min(shape) == 1
+        Test.@test SD.get_j_max(shape) == 2
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -1913,6 +2034,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.Circle(SD.Point(10, 10), 30)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 10
+        Test.@test SD.get_i_max(shape) == 39
+        Test.@test SD.get_j_min(shape) == 10
+        Test.@test SD.get_j_max(shape) == 39
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -1954,6 +2080,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.Circle(SD.Point(100 + 2, 100 + 2), 30)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 100 + 2
+        Test.@test SD.get_i_max(shape) == 100 + 31
+        Test.@test SD.get_j_min(shape) == 100 + 2
+        Test.@test SD.get_j_max(shape) == 100 + 31
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == falses(height, width)
@@ -2229,6 +2360,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.ThickCircle(SD.Point(2, 2), 29, 5)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 2
+        Test.@test SD.get_i_max(shape) == 30
+        Test.@test SD.get_j_min(shape) == 2
+        Test.@test SD.get_j_max(shape) == 30
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -2270,6 +2406,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.ThickCircle(SD.Point(1, 1), 1, 1)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 1
+        Test.@test SD.get_i_max(shape) == 1
+        Test.@test SD.get_j_min(shape) == 1
+        Test.@test SD.get_j_max(shape) == 1
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -2311,6 +2452,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.ThickCircle(SD.Point(10, 10), 29, 5)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 10
+        Test.@test SD.get_i_max(shape) == 38
+        Test.@test SD.get_j_min(shape) == 10
+        Test.@test SD.get_j_max(shape) == 38
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -2352,6 +2498,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.ThickCircle(SD.Point(100 + 2, 100 + 2), 29, 5)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 100 + 2
+        Test.@test SD.get_i_max(shape) == 100 + 30
+        Test.@test SD.get_j_min(shape) == 100 + 2
+        Test.@test SD.get_j_max(shape) == 100 + 30
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == falses(height, width)
@@ -2362,6 +2513,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.ThickCircle(SD.Point(2, 2), 30, 4)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 2
+        Test.@test SD.get_i_max(shape) == 31
+        Test.@test SD.get_j_min(shape) == 2
+        Test.@test SD.get_j_max(shape) == 31
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -2403,6 +2559,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.ThickCircle(SD.Point(1, 1), 2, 1)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 1
+        Test.@test SD.get_i_max(shape) == 2
+        Test.@test SD.get_j_min(shape) == 1
+        Test.@test SD.get_j_max(shape) == 2
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -2444,6 +2605,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.ThickCircle(SD.Point(10, 10), 30, 4)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 10
+        Test.@test SD.get_i_max(shape) == 39
+        Test.@test SD.get_j_min(shape) == 10
+        Test.@test SD.get_j_max(shape) == 39
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -2485,6 +2651,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.ThickCircle(SD.Point(100 + 2, 100 + 2), 30, 4)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 100 + 2
+        Test.@test SD.get_i_max(shape) == 100 + 31
+        Test.@test SD.get_j_min(shape) == 100 + 2
+        Test.@test SD.get_j_max(shape) == 100 + 31
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == falses(height, width)
@@ -2495,6 +2666,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.FilledCircle(SD.Point(2, 2), 29)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 2
+        Test.@test SD.get_i_max(shape) == 30
+        Test.@test SD.get_j_min(shape) == 2
+        Test.@test SD.get_j_max(shape) == 30
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -2536,6 +2712,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.FilledCircle(SD.Point(1, 1), 1)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 1
+        Test.@test SD.get_i_max(shape) == 1
+        Test.@test SD.get_j_min(shape) == 1
+        Test.@test SD.get_j_max(shape) == 1
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -2577,6 +2758,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.FilledCircle(SD.Point(10, 10), 29)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 10
+        Test.@test SD.get_i_max(shape) == 38
+        Test.@test SD.get_j_min(shape) == 10
+        Test.@test SD.get_j_max(shape) == 38
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -2618,6 +2804,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.FilledCircle(SD.Point(100 + 2, 100 + 2), 29)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 100 + 2
+        Test.@test SD.get_i_max(shape) == 100 + 30
+        Test.@test SD.get_j_min(shape) == 100 + 2
+        Test.@test SD.get_j_max(shape) == 100 + 30
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == falses(height, width)
@@ -2628,6 +2819,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.FilledCircle(SD.Point(2, 2), 30)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 2
+        Test.@test SD.get_i_max(shape) == 31
+        Test.@test SD.get_j_min(shape) == 2
+        Test.@test SD.get_j_max(shape) == 31
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -2669,6 +2865,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.FilledCircle(SD.Point(1, 1), 2)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 1
+        Test.@test SD.get_i_max(shape) == 2
+        Test.@test SD.get_j_min(shape) == 1
+        Test.@test SD.get_j_max(shape) == 2
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -2710,6 +2911,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.FilledCircle(SD.Point(10, 10), 30)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 8 + 2
+        Test.@test SD.get_i_max(shape) == 8 + 31
+        Test.@test SD.get_j_min(shape) == 8 + 2
+        Test.@test SD.get_j_max(shape) == 8 + 31
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -2751,6 +2957,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.FilledCircle(SD.Point(100 + 2, 100 + 2), 30)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 100 + 2
+        Test.@test SD.get_i_max(shape) == 100 + 31
+        Test.@test SD.get_j_min(shape) == 100 + 2
+        Test.@test SD.get_j_max(shape) == 100 + 31
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == falses(height, width)
@@ -3211,6 +3422,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.Rectangle(SD.Point(9, 5), 16, 24)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 9
+        Test.@test SD.get_i_max(shape) == 24
+        Test.@test SD.get_j_min(shape) == 5
+        Test.@test SD.get_j_max(shape) == 28
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -3252,6 +3468,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.Rectangle(SD.Point(1, 1), 1, 1)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 1
+        Test.@test SD.get_i_max(shape) == 1
+        Test.@test SD.get_j_min(shape) == 1
+        Test.@test SD.get_j_max(shape) == 1
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -3293,6 +3514,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.Rectangle(SD.Point(24, 16), 16, 24)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 15 + 9
+        Test.@test SD.get_i_max(shape) == 15 + 24
+        Test.@test SD.get_j_min(shape) == 11 + 5
+        Test.@test SD.get_j_max(shape) == 11 + 28
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -3334,6 +3560,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.Rectangle(SD.Point(100 + 9, 100 + 5), 16, 24)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 100 + 9
+        Test.@test SD.get_i_max(shape) == 100 + 24
+        Test.@test SD.get_j_min(shape) == 100 + 5
+        Test.@test SD.get_j_max(shape) == 100 + 28
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == falses(height, width)
@@ -3344,6 +3575,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.FilledRectangle(SD.Point(9, 5), 16, 24)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 9
+        Test.@test SD.get_i_max(shape) == 24
+        Test.@test SD.get_j_min(shape) == 5
+        Test.@test SD.get_j_max(shape) == 28
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -3385,6 +3621,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.FilledRectangle(SD.Point(1, 1), 1, 1)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 1
+        Test.@test SD.get_i_max(shape) == 1
+        Test.@test SD.get_j_min(shape) == 1
+        Test.@test SD.get_j_max(shape) == 1
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -3426,6 +3667,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.FilledRectangle(SD.Point(24, 16), 16, 24)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 15 + 9
+        Test.@test SD.get_i_max(shape) == 15 + 24
+        Test.@test SD.get_j_min(shape) == 11 + 5
+        Test.@test SD.get_j_max(shape) == 11 + 28
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -3467,6 +3713,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.FilledRectangle(SD.Point(100 + 9, 100 + 5), 16, 24)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 100 + 9
+        Test.@test SD.get_i_max(shape) == 100 + 24
+        Test.@test SD.get_j_min(shape) == 100 + 5
+        Test.@test SD.get_j_max(shape) == 100 + 28
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == falses(height, width)
@@ -3477,6 +3728,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.ThickRectangle(SD.Point(9, 5), 16, 24, 4)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 9
+        Test.@test SD.get_i_max(shape) == 24
+        Test.@test SD.get_j_min(shape) == 5
+        Test.@test SD.get_j_max(shape) == 28
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -3518,6 +3774,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.ThickRectangle(SD.Point(1, 1), 1, 1, 1)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 1
+        Test.@test SD.get_i_max(shape) == 1
+        Test.@test SD.get_j_min(shape) == 1
+        Test.@test SD.get_j_max(shape) == 1
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -3559,6 +3820,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.ThickRectangle(SD.Point(1, 1), 2, 2, 2)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 1
+        Test.@test SD.get_i_max(shape) == 2
+        Test.@test SD.get_j_min(shape) == 1
+        Test.@test SD.get_j_max(shape) == 2
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -3600,6 +3866,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.ThickRectangle(SD.Point(24, 16), 16, 24, 4)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 15 + 9
+        Test.@test SD.get_i_max(shape) == 15 + 24
+        Test.@test SD.get_j_min(shape) == 11 + 5
+        Test.@test SD.get_j_max(shape) == 11 + 28
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -3641,6 +3912,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.ThickRectangle(SD.Point(100 + 9, 100 + 5), 16, 24, 4)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 100 + 9
+        Test.@test SD.get_i_max(shape) == 100 + 24
+        Test.@test SD.get_j_min(shape) == 100 + 5
+        Test.@test SD.get_j_max(shape) == 100 + 28
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == falses(height, width)
@@ -3651,6 +3927,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.FilledTriangle(SD.Point(5, 14), SD.Point(18, 3), SD.Point(26, 28))
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 5
+        Test.@test SD.get_i_max(shape) == 26
+        Test.@test SD.get_j_min(shape) == 3
+        Test.@test SD.get_j_max(shape) == 28
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -3692,6 +3973,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.FilledTriangle(SD.Point(1, 1), SD.Point(1, 1), SD.Point(1, 1))
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 1
+        Test.@test SD.get_i_max(shape) == 1
+        Test.@test SD.get_j_min(shape) == 1
+        Test.@test SD.get_j_max(shape) == 1
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -3733,6 +4019,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.FilledTriangle(SD.Point(-1, 1), SD.Point(3, 1), SD.Point(5, 1))
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == -1
+        Test.@test SD.get_i_max(shape) == 5
+        Test.@test SD.get_j_min(shape) == 1
+        Test.@test SD.get_j_max(shape) == 1
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -3774,6 +4065,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.FilledTriangle(SD.Point(1, -1), SD.Point(1, 3), SD.Point(1, 5))
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 1
+        Test.@test SD.get_i_max(shape) == 1
+        Test.@test SD.get_j_min(shape) == -1
+        Test.@test SD.get_j_max(shape) == 5
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -3814,7 +4110,12 @@ Test.@testset "SimpleDraw.jl" begin
         height = 32
         width = 32
         image = falses(height, width)
-        shape = SD.FilledTriangle(SD.Point(105, 114), SD.Point(118, 103), SD.Point(126, 128))
+        shape = SD.FilledTriangle(SD.Point(100 + 5, 100 + 14), SD.Point(100 + 18, 100 + 3), SD.Point(100 + 26, 100 + 28))
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 100 + 5
+        Test.@test SD.get_i_max(shape) == 100 + 26
+        Test.@test SD.get_j_min(shape) == 100 + 3
+        Test.@test SD.get_j_max(shape) == 100 + 28
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == falses(height, width)
@@ -3825,6 +4126,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.Character(SD.Point(1, 1), 'A', SD.TERMINUS_32_16)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 1
+        Test.@test SD.get_i_max(shape) == 32
+        Test.@test SD.get_j_min(shape) == 1
+        Test.@test SD.get_j_max(shape) == 16
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -3866,9 +4172,21 @@ Test.@testset "SimpleDraw.jl" begin
         width = 32
         image = falses(height, width)
         shape = SD.Character(SD.Point(100 + 1, 100 + 1), 'A', SD.TERMINUS_32_16)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 100 + 1
+        Test.@test SD.get_i_max(shape) == 100 + 32
+        Test.@test SD.get_j_min(shape) == 100 + 1
+        Test.@test SD.get_j_max(shape) == 100 + 16
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == falses(height, width)
+
+        shape = SD.Character(SD.Point(1, 1), '\n', SD.TERMINUS_32_16)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 1
+        Test.@test SD.get_i_max(shape) == 1
+        Test.@test SD.get_j_min(shape) == 1
+        Test.@test SD.get_j_max(shape) == 1
     end
 
     Test.@testset "TextLine" begin
@@ -3876,6 +4194,11 @@ Test.@testset "SimpleDraw.jl" begin
         width = 64
         image = falses(height, width)
         shape = SD.TextLine(SD.Point(1, 1), "Text", SD.TERMINUS_32_16)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 1
+        Test.@test SD.get_i_max(shape) == 32
+        Test.@test SD.get_j_min(shape) == 1
+        Test.@test SD.get_j_max(shape) == 64
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -3917,9 +4240,28 @@ Test.@testset "SimpleDraw.jl" begin
         width = 64
         image = falses(height, width)
         shape = SD.TextLine(SD.Point(100 + 1, 100 + 1), "Text", SD.TERMINUS_32_16)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 100 + 1
+        Test.@test SD.get_i_max(shape) == 100 + 32
+        Test.@test SD.get_j_min(shape) == 100 + 1
+        Test.@test SD.get_j_max(shape) == 100 + 64
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == falses(height, width)
+
+        shape = SD.TextLine(SD.Point(1, 1), "A\nB", SD.TERMINUS_32_16)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 1
+        Test.@test SD.get_i_max(shape) == 32
+        Test.@test SD.get_j_min(shape) == 1
+        Test.@test SD.get_j_max(shape) == 32
+
+        shape = SD.TextLine(SD.Point(1, 1), "\n", SD.TERMINUS_32_16)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 1
+        Test.@test SD.get_i_max(shape) == 1
+        Test.@test SD.get_j_min(shape) == 1
+        Test.@test SD.get_j_max(shape) == 1
     end
 
     Test.@testset "Bitmap" begin
@@ -3945,6 +4287,11 @@ Test.@testset "SimpleDraw.jl" begin
                             0 0 0 0 0 0 0 1 1 0 0 0 0 0 0 0
                            ])
         shape = SD.Bitmap(SD.Point(1, 1), bitmap)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 1
+        Test.@test SD.get_i_max(shape) == 16
+        Test.@test SD.get_j_min(shape) == 1
+        Test.@test SD.get_j_max(shape) == 16
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -3988,6 +4335,11 @@ Test.@testset "SimpleDraw.jl" begin
         bitmap = BitMatrix(undef, 0, 0)
         fill!(bitmap, true)
         shape = SD.Bitmap(SD.Point(1, 1), bitmap)
+        Test.@test SD.get_i_min(shape) == 1
+        Test.@test SD.get_i_max(shape) == 1
+        Test.@test SD.get_j_min(shape) == 1
+        Test.@test SD.get_j_max(shape) == 1
+        Test.@test SD.is_valid(shape)
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == falses(height, width)
@@ -4014,6 +4366,11 @@ Test.@testset "SimpleDraw.jl" begin
                             0 0 0 0 0 0 0 1 1 0 0 0 0 0 0 0
                            ])
         shape = SD.Bitmap(SD.Point(25, 25), bitmap)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 24 + 1
+        Test.@test SD.get_i_max(shape) == 24 + 16
+        Test.@test SD.get_j_min(shape) == 24 + 1
+        Test.@test SD.get_j_max(shape) == 24 + 16
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == BitArray([
@@ -4073,6 +4430,11 @@ Test.@testset "SimpleDraw.jl" begin
                             0 0 0 0 0 0 0 1 1 0 0 0 0 0 0 0
                            ])
         shape = SD.Bitmap(SD.Point(100 + 25, 100 + 25), bitmap)
+        Test.@test SD.is_valid(shape)
+        Test.@test SD.get_i_min(shape) == 100 + 24 + 1
+        Test.@test SD.get_i_max(shape) == 100 + 24 + 16
+        Test.@test SD.get_j_min(shape) == 100 + 24 + 1
+        Test.@test SD.get_j_max(shape) == 100 + 24 + 16
         color = true
         SD.draw!(image, shape, color)
         Test.@test image == falses(height, width)


### PR DESCRIPTION
1. add `is_valid`, `get_i_min`, `get_i_max`, `get_j_min`, `get_j_max` to the official API. Add methods for shapes that did not have them.
2. For `Bitmap`, `Character`, `TextLine`, if the bitmap is empty or if characters are non-printable, then `i_min == i_max` and `j_min == j_max`
3. Fix bug in `get_i_max` for `ThickLine`.
4. Use the general `convert(I, 2)` instead of just `2`.